### PR TITLE
Feature 251/qa server support

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,14 @@
 import dynamic from 'next/dynamic'
 import Layout from '@components/Layout'
 import CircularProgress from '@components/CircularProgress'
+import { useRouter } from 'next/router'
+import { useContext, useEffect } from 'react'
+import {
+  BASE_URL,
+  PROD, QA,
+  QA_BASE_URL,
+} from '@common/constants'
+import { AuthContext } from '@context/AuthContext'
 
 const WorkspaceContainer = dynamic(
   () => import('@components/WorkspaceContainer'),
@@ -10,10 +18,33 @@ const WorkspaceContainer = dynamic(
   }
 )
 
-const Home = () => (
-  <Layout>
-    <WorkspaceContainer />
-  </Layout>
-)
+const Home = () => {
+  const router = useRouter()
+  const {
+    state: { server },
+    actions: { setServer },
+  } = useContext(AuthContext)
+
+  useEffect(() => {
+    const params = router.query
+
+    if (typeof params.server === 'string') { // if URL param given
+      const serverID_ = params.server.toUpperCase() === QA ? QA : PROD
+      const server_ = (serverID_ === QA) ? QA_BASE_URL : BASE_URL
+
+      if (server !== server_) {
+        console.log(`index.js - On init switching server to: ${serverID_}, url server param ${params.server}, reloading page`)
+        setServer(server_)
+        router.push(`/?server=${serverID_}`) // reload page with new server
+      }
+    }
+  }, [router.query]) // TRICKY query property not loaded on first pass, so watch for change
+
+  return (
+    <Layout>
+      <WorkspaceContainer/>
+    </Layout>
+  )
+}
 
 export default Home

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,14 +1,6 @@
 import dynamic from 'next/dynamic'
 import Layout from '@components/Layout'
 import CircularProgress from '@components/CircularProgress'
-import { useRouter } from 'next/router'
-import { useContext, useEffect } from 'react'
-import {
-  BASE_URL,
-  PROD, QA,
-  QA_BASE_URL,
-} from '@common/constants'
-import { AuthContext } from '@context/AuthContext'
 
 const WorkspaceContainer = dynamic(
   () => import('@components/WorkspaceContainer'),
@@ -18,33 +10,10 @@ const WorkspaceContainer = dynamic(
   }
 )
 
-const Home = () => {
-  const router = useRouter()
-  const {
-    state: { server },
-    actions: { setServer },
-  } = useContext(AuthContext)
-
-  useEffect(() => {
-    const params = router.query
-
-    if (typeof params.server === 'string') { // if URL param given
-      const serverID_ = params.server.toUpperCase() === QA ? QA : PROD
-      const server_ = (serverID_ === QA) ? QA_BASE_URL : BASE_URL
-
-      if (server !== server_) {
-        console.log(`index.js - On init switching server to: ${serverID_}, url server param ${params.server}, reloading page`)
-        setServer(server_)
-        router.push(`/?server=${serverID_}`) // reload page with new server
-      }
-    }
-  }, [router.query]) // TRICKY query property not loaded on first pass, so watch for change
-
-  return (
-    <Layout>
-      <WorkspaceContainer/>
-    </Layout>
-  )
-}
+const Home = () => (
+  <Layout>
+    <WorkspaceContainer />
+  </Layout>
+)
 
 export default Home

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -8,6 +8,7 @@ export const QA = 'QA'
 export const PROD = 'PROD'
 export const TOKEN_ID = 'gatewayEdit'
 export const FEEDBACK_PAGE = '/feedback'
+export const SERVER_KEY = 'server'
 
 export const SERVER_MAX_WAIT_TIME_RETRY = 10000 // in milliseconds
 export const HTTP_GET_MAX_WAIT_TIME = 5000 // in milliseconds

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -3,6 +3,9 @@ import packagefile from '../../package.json'
 export const APP_VERSION = packagefile.version
 export const APP_NAME = 'gatewayEdit'
 export const BASE_URL = 'https://git.door43.org'
+export const QA_BASE_URL = 'https://qa.door43.org'
+export const QA = 'QA'
+export const PROD = 'PROD'
 export const TOKEN_ID = 'gatewayEdit'
 export const FEEDBACK_PAGE = '/feedback'
 

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 export default function Footer({
   buildVersion,
   buildHash,
+  serverID,
 }) {
   return (
     <footer className='flex justify-between items-center h-20 w-screen bg-primary border border-solid border-gray-200'>
@@ -12,6 +13,7 @@ export default function Footer({
         <div className='text-white w-max pl-5'>
           <span id='build_version'>{`v${buildVersion} `}</span>
           <span id='build_hash' style={{ fontSize: '0.6em' }}>{`build ${buildHash}`}</span>
+          <span id='server'>{` ${serverID}`}</span>
         </div>
       </Typography>
       <NetlifyBadge />
@@ -23,4 +25,5 @@ export default function Footer({
 Footer.propTypes = {
   buildVersion: PropTypes.string,
   buildHash: PropTypes.string,
+  serverID: PropTypes.string,
 }

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from 'react'
+import { useContext, useEffect, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { AuthenticationContext } from 'gitea-react-toolkit'
 import Header from '@components/Header'
@@ -6,14 +6,16 @@ import Footer from '@components/Footer'
 import Onboarding from '@components/Onboarding'
 import { StoreContext } from '@context/StoreContext'
 import { getBuildId } from '@utils/build'
-import { APP_NAME, QA, QA_BASE_URL } from '@common/constants'
+import { APP_NAME, BASE_URL, PROD, QA, QA_BASE_URL } from '@common/constants'
 import useValidateAccountSettings from '@hooks/useValidateAccountSettings'
+import { useRouter } from 'next/router'
 
 export default function Layout({
   children,
   showChildren,
   title = APP_NAME,
 }) {
+  const router = useRouter()
   const {
     state: authentication,
     component: authenticationComponent,
@@ -29,8 +31,24 @@ export default function Layout({
     actions: {
       setCurrentLayout,
       setShowAccountSetup,
+      setServer,
     },
   } = useContext(StoreContext)
+
+  useEffect(() => {
+    const params = router?.query
+
+    if (typeof params?.server === 'string') { // if URL param given
+      const serverID_ = params.server.toUpperCase() === QA ? QA : PROD
+      const server_ = (serverID_ === QA) ? QA_BASE_URL : BASE_URL
+
+      if (server !== server_) {
+        console.log(`_app.js - On init switching server to: ${serverID_}, url server param '${params.server}', old server ${server}, reloading page`)
+        setServer(server_) // persist server selection in localstorage
+        router.push(`/?server=${serverID_}`) // reload page
+      }
+    }
+  }, [router?.query]) // TRICKY query property not loaded on first pass, so watch for change
 
   const buildId = useMemo(getBuildId, [])
   useValidateAccountSettings(authentication, showAccountSetup, languageId, owner, setShowAccountSetup)

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -6,7 +6,7 @@ import Footer from '@components/Footer'
 import Onboarding from '@components/Onboarding'
 import { StoreContext } from '@context/StoreContext'
 import { getBuildId } from '@utils/build'
-import { APP_NAME } from '@common/constants'
+import { APP_NAME, QA, QA_BASE_URL } from '@common/constants'
 import useValidateAccountSettings from '@hooks/useValidateAccountSettings'
 
 export default function Layout({
@@ -24,6 +24,7 @@ export default function Layout({
       showAccountSetup,
       languageId,
       owner,
+      server,
     },
     actions: {
       setCurrentLayout,
@@ -54,6 +55,7 @@ export default function Layout({
       <Footer
         buildHash={buildId?.hash}
         buildVersion={buildId?.version}
+        serverID={(server === QA_BASE_URL) ? QA : ''}
       />
     </div>
   )

--- a/src/components/WorkspaceContainer.js
+++ b/src/components/WorkspaceContainer.js
@@ -95,7 +95,6 @@ function WorkspaceContainer() {
       updateTaDetails,
       setGreekRepoUrl,
       setHebrewRepoUrl,
-      setServer,
     },
   } = useContext(StoreContext)
 
@@ -253,7 +252,7 @@ function WorkspaceContainer() {
    * @return {Promise<*>}
    */
   async function getLatestBibleRepo(org, lang, bible) {
-    const url = `https://git.door43.org/api/catalog/v5/search/${org}/${lang}_${bible}`
+    const url = `${server}/api/catalog/v5/search/${org}/${lang}_${bible}`
     const results = await doFetch(url, {}, HTTP_GET_MAX_WAIT_TIME)
       .then(response => {
         if (response?.status !== 200) {
@@ -311,20 +310,6 @@ function WorkspaceContainer() {
         setTimeout(() => { setWorkspaceReady(true) }, 500)
       }
     })
-  }, [])
-
-  useEffect(() => {
-    const params = router.query
-
-    if (typeof params.server === 'string') { // if URL param given
-      const serverID_ = params.server.toUpperCase() === QA ? QA : PROD
-      const server_ = (serverID_ === QA) ? QA_BASE_URL : BASE_URL
-
-      if (server !== server_) {
-        console.log(`On init switching server to: ${serverID_}, url server param ${params.server}`)
-        setServer(server_)
-      }
-    }
   }, [])
 
   const isNewTestament = isNT(bookId)

--- a/src/components/WorkspaceContainer.js
+++ b/src/components/WorkspaceContainer.js
@@ -35,7 +35,14 @@ import {
   reloadApp,
 } from '@utils/network'
 import { useRouter } from 'next/router'
-import { HTTP_CONFIG, HTTP_GET_MAX_WAIT_TIME } from '@common/constants'
+import {
+  BASE_URL,
+  HTTP_CONFIG,
+  HTTP_GET_MAX_WAIT_TIME,
+  PROD,
+  QA,
+  QA_BASE_URL,
+} from '@common/constants'
 import NetworkErrorPopup from '@components/NetworkErrorPopUp'
 
 const useStyles = makeStyles(() => ({
@@ -88,6 +95,7 @@ function WorkspaceContainer() {
       updateTaDetails,
       setGreekRepoUrl,
       setHebrewRepoUrl,
+      setServer,
     },
   } = useContext(StoreContext)
 
@@ -303,6 +311,20 @@ function WorkspaceContainer() {
         setTimeout(() => { setWorkspaceReady(true) }, 500)
       }
     })
+  }, [])
+
+  useEffect(() => {
+    const params = router.query
+
+    if (typeof params.server === 'string') { // if URL param given
+      const serverID_ = params.server.toUpperCase() === QA ? QA : PROD
+      const server_ = (serverID_ === QA) ? QA_BASE_URL : BASE_URL
+
+      if (server !== server_) {
+        console.log(`On init switching server to: ${serverID_}, url server param ${params.server}`)
+        setServer(server_)
+      }
+    }
   }, [])
 
   const isNewTestament = isNT(bookId)

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -5,6 +5,7 @@ import {
   BASE_URL,
   CLOSE,
   HTTP_GET_MAX_WAIT_TIME,
+  SERVER_KEY,
   TOKEN_ID,
 } from '@common/constants'
 import {
@@ -13,12 +14,14 @@ import {
   unAuthenticated,
 } from '@utils/network'
 import NetworkErrorPopup from '@components/NetworkErrorPopUp'
+import useLocalStorage from '@hooks/useLocalStorage'
 
 export const AuthContext = createContext({})
 
 export default function AuthContextProvider(props) {
   const [authentication, setAuthentication] = useState(null)
   const [networkError, setNetworkError] = useState(null)
+  const [server, setServer] = useLocalStorage(SERVER_KEY, BASE_URL)
 
   /**
    * in the case of a network error, process and display error dialog
@@ -38,7 +41,7 @@ export default function AuthContextProvider(props) {
     const auth = await myAuthStore.getItem('authentication')
 
     if (auth) { // verify that auth is still valid
-      doFetch('https://git.door43.org/api/v1/user', auth, HTTP_GET_MAX_WAIT_TIME)
+      doFetch(`${server}/api/v1/user`, auth, HTTP_GET_MAX_WAIT_TIME)
         .then(response => {
           const httpCode = response?.status || 0
 
@@ -94,10 +97,12 @@ export default function AuthContextProvider(props) {
     state: {
       authentication,
       networkError,
+      server,
     },
     actions: {
       logout,
       setNetworkError,
+      setServer,
     },
   }
 
@@ -105,7 +110,7 @@ export default function AuthContextProvider(props) {
     <AuthContext.Provider value={value}>
       <AuthenticationContextProvider
         config={{
-          server: BASE_URL,
+          server,
           tokenid: TOKEN_ID,
           timeout: HTTP_GET_MAX_WAIT_TIME,
         }}

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useState } from 'react'
+import React, {createContext, useContext, useEffect, useState} from 'react'
 import localforage from 'localforage'
 import { AuthenticationContextProvider } from 'gitea-react-toolkit'
 import {

--- a/src/context/StoreContext.js
+++ b/src/context/StoreContext.js
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types'
 import useLocalStorage from '@hooks/useLocalStorage'
 import * as useULS from '@hooks/useUserLocalStorage'
 import { AuthContext } from '@context/AuthContext'
-import { BASE_URL } from '@common/constants'
 
 export const StoreContext = createContext({})
 
@@ -16,10 +15,12 @@ export default function StoreContextProvider(props) {
     state: {
       authentication,
       networkError: tokenNetworkError,
+      server,
     },
     actions: {
       logout,
       setNetworkError: setTokenNetworkError,
+      setServer,
     },
   } = useContext(AuthContext)
   const username = authentication?.user?.username || ''
@@ -45,7 +46,6 @@ export default function StoreContextProvider(props) {
   const [selectedQuote, setQuote] = useUserLocalStorage('selectedQuote', null)
   // TODO blm: for now we use unfoldingWord for original language bibles
   const [scriptureOwner, setScriptureOwner] = useState('unfoldingWord')
-  const [server, setServer] = useUserLocalStorage('server', BASE_URL)
   const [appRef, setAppRef] = useUserLocalStorage('appRef', 'master') // default for app
   const [bibleReference, setBibleReference] = useUserLocalStorage('bibleReference', {
     bookId: 'mat',

--- a/src/context/StoreContext.js
+++ b/src/context/StoreContext.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types'
 import useLocalStorage from '@hooks/useLocalStorage'
 import * as useULS from '@hooks/useUserLocalStorage'
 import { AuthContext } from '@context/AuthContext'
+import { BASE_URL } from '@common/constants'
 
 export const StoreContext = createContext({})
 
@@ -44,7 +45,7 @@ export default function StoreContextProvider(props) {
   const [selectedQuote, setQuote] = useUserLocalStorage('selectedQuote', null)
   // TODO blm: for now we use unfoldingWord for original language bibles
   const [scriptureOwner, setScriptureOwner] = useState('unfoldingWord')
-  const [server, setServer] = useState('https://git.door43.org')
+  const [server, setServer] = useUserLocalStorage('server', BASE_URL)
   const [appRef, setAppRef] = useUserLocalStorage('appRef', 'master') // default for app
   const [bibleReference, setBibleReference] = useUserLocalStorage('bibleReference', {
     bookId: 'mat',

--- a/src/utils/network.js
+++ b/src/utils/network.js
@@ -13,6 +13,7 @@ import {
   LOCAL_NETWORK_DISCONNECTED_ERROR,
   LOGIN,
   SEND_FEEDBACK,
+  SERVER_KEY,
   SERVER_MAX_WAIT_TIME_RETRY,
   SERVER_OTHER_ERROR,
   SERVER_UNREACHABLE_ERROR,
@@ -42,7 +43,7 @@ export async function getServerFault() {
     const secondTry = getLocalStorageItem(SERVER_CHECK_SECOND_TRY_KEY)
     setLocalStorageValue(SERVER_CHECK_SECOND_TRY_KEY, false) // clear flag
     const timeout = secondTry ? HTTP_GET_MAX_WAIT_TIME : SERVER_MAX_WAIT_TIME_RETRY
-    await checkIfServerOnline(BASE_URL, { timeout }) // throws exception if server disconnected
+    await checkIfServerOnline(getLocalStorageItem(SERVER_KEY), { timeout }) // throws exception if server disconnected
     return null
   } catch (e) {
     console.warn(`getServerFault() - received error`, e)


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] fixed locations that were not using server variable
- [ ] moved server state variable to StoreContext and persisted in local storage
- [ ] added indicator to app that we are in QA mode 

## Test Instructions
- test with https://deploy-preview-264--gateway-edit.netlify.app/
- [x] open dev tools
- [x] login to app and save login, select test_org/en and save, wait for all resource panes to load
- [x] in dev tools look at network activity. do filter for `url: git.door43.org`, should see lots of fetches:

<img width="1027" alt="Screen Shot 2021-07-30 at 6 54 15 AM" src="https://user-images.githubusercontent.com/14238574/127643176-49c67a67-6440-4e10-946c-7fae79ce5d72.png">

- [x] now do filter for `url: qa.door43.org`, should no matches
- [x] change the url to `https://deploy-preview-264--gateway-edit.netlify.app/?server=QA` and hit enter
- [x] this should restart the app and log you out since it is now  qa server
- [x] login to app and save login, select test_org/en and save, wait for all resource panes to load
- [x] should see QA indicator in footer:

<img width="234" alt="Screen Shot 2021-07-30 at 7 00 23 AM" src="https://user-images.githubusercontent.com/14238574/127643878-90aa50cc-f8ab-4ea2-bf61-991d534f0642.png">

- [x] in dev tools look at network activity. do filter for `url: qa.door43.org`, should see lots of fetches
- [x] now do filter for `url: git.door43.org`, should see a few matches early before page is reloaded with qa:

<img width="1089" alt="Screen Shot 2021-07-30 at 6 42 53 AM" src="https://user-images.githubusercontent.com/14238574/127642748-e88ffb74-8bba-479d-880a-f67e2f1fc397.png">

- [x] change url to `https://deploy-preview-264--gateway-edit.netlify.app/?server=PROD` and hit enter
- [x] should log you out again as it switches back
- [x] should no longer see QA indicator in footer.


# Reviewable: https://reviewable.io/reviews/unfoldingWord/gateway-edit/264#-