### PR TITLE
Feature 106/Add email address error prompting to feedback form

### DIFF
--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -250,7 +250,6 @@ const SettingsPage = () => {
                 label='Email'
                 error={!!emailError}
                 helperText={emailError}
-                // pattern=".+@beststartupever\.com"
                 autoComplete='email'
                 defaultValue={email}
                 variant='outlined'

--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -110,12 +110,8 @@ const SettingsPage = () => {
   }
 
   function onEmailChange(e) {
-    const validationError = e.target?.validationMessage
+    const validationError = e?.target?.validationMessage
     setEmailError(validationError)
-
-    if (validationError) {
-      console.log('email invalid', validationError)
-    }
     setEmail(e.target.value)
   }
 

--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -110,7 +110,7 @@ const SettingsPage = () => {
   }
 
   function onEmailChange(e) {
-    const validationError = e?.target?.validationMessage
+    const validationError = e?.target?.validationMessage || null
     setEmailError(validationError)
     setEmail(e.target.value)
   }

--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -67,6 +67,7 @@ const SettingsPage = () => {
   const [category, setCategory] = useState('')
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
+  const [emailError, setEmailError] = useState(null)
   const [message, setMessage] = useState('')
   const [networkError, setNetworkError] = useState(null)
 
@@ -109,6 +110,12 @@ const SettingsPage = () => {
   }
 
   function onEmailChange(e) {
+    const validationError = e.target?.validationMessage
+    setEmailError(validationError)
+
+    if (validationError) {
+      console.log('email invalid', validationError)
+    }
     setEmail(e.target.value)
   }
 
@@ -245,6 +252,9 @@ const SettingsPage = () => {
                 id='Email-feedback-form'
                 type='email'
                 label='Email'
+                error={!!emailError}
+                helperText={emailError}
+                // pattern=".+@beststartupever\.com"
                 autoComplete='email'
                 defaultValue={email}
                 variant='outlined'
@@ -287,7 +297,7 @@ const SettingsPage = () => {
                   size='large'
                   disableElevation
                   disabled={
-                    submitting || !name || !email || !message || !category
+                    submitting || !name || !email || !message || !category || !!emailError
                   }
                   onClick={onSubmitFeedback}
                 >


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] add email address error prompting for invalid email addresses base on browser's hinting

## Test Instructions
- test with https://deploy-preview-270--gateway-edit.netlify.app/
- [ ] log into app, select org and language if needed
- [ ] using menu select `Bug Report or Feedback`
- [ ] try various email examples shown at bottom of issue https://github.com/unfoldingword/gateway-edit/issues/106 
  - note that the hint text is browser dependent.  also the email validation is very basic and also may be browser dependent
- [ ] make sure that submit button is enabled only if all fields have text or selection, and email address must pass browser validation.

# Reviewable: https://reviewable.io/reviews/unfoldingWord/gateway-edit/270#-