### PR TITLE
Feature 106/email validation

### DIFF
--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -162,6 +162,7 @@ const SettingsPage = () => {
 
     if (emailError) { // if there is currently an error on the email address, show to user and abort submitting feedback
       setShowEmailError(true)
+      // TODO: BLM - set focus on email address
       return
     }
 

--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -158,12 +158,14 @@ const SettingsPage = () => {
   }
 
   async function onSubmitFeedback() {
+    setShowSuccess(false)
+
     if (emailError) { // if there is currently an error on the email, show to user and abort feedback
       setShowEmailError(true)
       return
     }
+
     setSubmitting(true)
-    setShowSuccess(false)
     setShowError(false)
     const build = getBuildId()
     const scriptureCardSettings = getScriptureCardSettings(loggedInUser)

--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react'
+import { useContext, useRef, useState } from 'react'
 import { useRouter } from 'next/router'
 import Paper from 'translation-helps-rcl/dist/components/Paper'
 import { makeStyles } from '@material-ui/core/styles'
@@ -71,6 +71,7 @@ const SettingsPage = () => {
   const [showEmailError, setShowEmailError] = useState(false)
   const [message, setMessage] = useState('')
   const [networkError, setNetworkError] = useState(null)
+  const emailEditRef = useRef(null)
 
   const {
     state: {
@@ -162,7 +163,7 @@ const SettingsPage = () => {
 
     if (emailError) { // if there is currently an error on the email address, show to user and abort submitting feedback
       setShowEmailError(true)
-      // TODO: BLM - set focus on email address
+      emailEditRef.current.focus()
       return
     }
 
@@ -267,6 +268,7 @@ const SettingsPage = () => {
                 variant='outlined'
                 onChange={onEmailChange}
                 classes={{ root: classes.textField }}
+                inputRef={emailEditRef}
               />
               <FormControl variant='outlined' className={classes.formControl}>
                 <InputLabel id='categories-dropdown-label'>

--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -68,6 +68,7 @@ const SettingsPage = () => {
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [emailError, setEmailError] = useState(null)
+  const [showEmailError, setShowEmailError] = useState(false)
   const [message, setMessage] = useState('')
   const [networkError, setNetworkError] = useState(null)
 
@@ -112,6 +113,10 @@ const SettingsPage = () => {
   function onEmailChange(e) {
     const validationError = e?.target?.validationMessage || null
     setEmailError(validationError)
+
+    if (!validationError) { // if email address corrected, then clear displayed warning
+      setShowEmailError(false)
+    }
     setEmail(e.target.value)
   }
 
@@ -153,6 +158,10 @@ const SettingsPage = () => {
   }
 
   async function onSubmitFeedback() {
+    if (emailError) { // if there is currently an error on the email, show to user and abort feedback
+      setShowEmailError(true)
+      return
+    }
     setSubmitting(true)
     setShowSuccess(false)
     setShowError(false)
@@ -248,8 +257,8 @@ const SettingsPage = () => {
                 id='Email-feedback-form'
                 type='email'
                 label='Email'
-                error={!!emailError}
-                helperText={emailError}
+                error={showEmailError}
+                helperText={showEmailError ? emailError : null}
                 autoComplete='email'
                 defaultValue={email}
                 variant='outlined'
@@ -292,7 +301,7 @@ const SettingsPage = () => {
                   size='large'
                   disableElevation
                   disabled={
-                    submitting || !name || !email || !message || !category || !!emailError
+                    submitting || !name || !email || !message || !category
                   }
                   onClick={onSubmitFeedback}
                 >

--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -114,7 +114,7 @@ const SettingsPage = () => {
     const validationError = e?.target?.validationMessage || null
     setEmailError(validationError)
 
-    if (!validationError) { // if email address corrected, then clear displayed warning
+    if (!validationError) { // if email address error corrected, then clear any displayed warning
       setShowEmailError(false)
     }
     setEmail(e.target.value)
@@ -160,7 +160,7 @@ const SettingsPage = () => {
   async function onSubmitFeedback() {
     setShowSuccess(false)
 
-    if (emailError) { // if there is currently an error on the email, show to user and abort feedback
+    if (emailError) { // if there is currently an error on the email address, show to user and abort submitting feedback
       setShowEmailError(true)
       return
     }


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] add email address error prompting for invalid email addresses base on browser's hinting

## Test Instructions
- test with https://deploy-preview-271--gateway-edit.netlify.app/
- [x] log into app, select org and language if needed
- [x] using menu select `Bug Report or Feedback`
- [x] if you enter an invalid email address (such as the invalid email examples shown at bottom of https://github.com/unfoldingword/gateway-edit/issues/106) and click submit you should see an email address invalid warning and focus show move to email input.
  - note that the email validation is very basic and also may be browser dependent.  It appears to make sure there is one and only one `@` and address does not end in a period
- [ ] when you correct the email address, the warning will clear as soon as it appears valid to the browser.  Then when you click submit again it will re-validate the email address again.

# Reviewable: https://reviewable.io/reviews/unfoldingWord/gateway-edit/271#-
