### PR TITLE
Fixed sorting of TSV items with verse spans 

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "single-scripture-rcl": "3.1.0",
     "tailwindcss": "^2.0.4",
     "tc-ui-toolkit": "5.3.3",
-    "translation-helps-rcl": "^3.1.1-rc1",
+    "translation-helps-rcl": "3.1.1",
     "use-deep-compare-effect": "^1.3.1",
     "word-aligner": "^1.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7709,10 +7709,10 @@ transform-runtime@0.0.0:
   resolved "https://registry.yarnpkg.com/transform-runtime/-/transform-runtime-0.0.0.tgz#e714d9b69211dd9537939d50e3aa5788c442b85c"
   integrity sha1-5xTZtpIR3ZU3k51Q46pXiMRCuFw=
 
-translation-helps-rcl@^3.1.1-rc1:
-  version "3.1.1-rc1"
-  resolved "https://registry.yarnpkg.com/translation-helps-rcl/-/translation-helps-rcl-3.1.1-rc1.tgz#01e9bae05160a733105da2f16c6fd6af8aff3308"
-  integrity sha512-mGpPXkRKLmJ32sCHqWtKAwLM/mI4lbXR80obniqnZ1CjmjCutCVmj/e6z48QJynBu1wUi6ohUROJw0cuZzVanw==
+translation-helps-rcl@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/translation-helps-rcl/-/translation-helps-rcl-3.1.1.tgz#167d4a48c9240f7c979c57833087d4e5f8c54689"
+  integrity sha512-gdxK24RtkPxSnck11+gryXmMbhcoh7BmmHCe17DgU+tPdyvyU4hmg/y0TLEaPA1d+dhUbowbp2evSnmpdX4xoQ==
   dependencies:
     axios "^0.21.1"
     deep-equal "^2.0.5"


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ]

## Test Instructions

- [ ] Open https://deploy-preview-300--gateway-edit.netlify.app/
- [ ] Clear local storage.
- [ ] Login and select test_org and English.
- [ ] Delete your user branch on [en_tn/branches](https://git.door43.org/test_org/en_tn/branches), if you have one.
- [ ] Select Titus 1:1 in the bible reference dropdown
- [ ] Make an edit in the first tn item.
- [ ] Now go to your user branch and in the TIT file change `1:1  	rtc9` to `1:1-2	rtc9`
- [ ] Go back to the app
- [ ] Clear local storage.
- [ ] Login and select test_org and English.
- [ ] Now edit the first item in the tn card (Should be reference 1:1 and ID xyz8)
- [ ] Now go on https://git.door43.org/test_org/en_tn and verify that in your user branch the diffs look like https://git.door43.org/test_org/en_tn/commit/bb86c2b60cf250bfe8af3ed4586313a2f347b406
- [ ] 1:1-2 should be between 1:1 and 1:2
