### PR TITLE
Added badges version number for main and develop branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/58e59c6e-0cea-43cd-b535-86d3495ce3c9/deploy-status)](https://app.netlify.com/sites/gateway-edit/deploys)
 [![CI Status](https://github.com/unfoldingWord/gateway-edit/workflows/Run%20Cypress%20and%20Jest%20Tests/badge.svg)](https://github.com/unfoldingWord/gateway-edit/actions)
-[![Current Verison](https://img.shields.io/github/tag/unfoldingWord/gateway-edit.svg)](https://github.com/unfoldingWord/gateway-edit/tags)
 
 Main:
+[![Current Verison](https://img.shields.io/github/package-json/v/unfoldingWord/gateway-edit/main)](https://github.com/unfoldingWord/gateway-edit/tags)
 [![codecov](https://codecov.io/gh/unfoldingWord/gateway-edit/branch/main/graph/badge.svg?token=0HTP1JR1UL)](https://codecov.io/gh/unfoldingWord/gateway-edit)
 Develop:
+[![Current Verison](https://img.shields.io/github/package-json/v/unfoldingWord/gateway-edit/develop)](https://github.com/unfoldingWord/gateway-edit/tags)
 [![codecov](https://codecov.io/gh/unfoldingWord/gateway-edit/branch/develop/graph/badge.svg?token=0HTP1JR1UL)](https://codecov.io/gh/unfoldingWord/gateway-edit)
 
 Book Package harmonized view.


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ]

## Test Instructions

- [x] Open https://github.com/unfoldingWord/gateway-edit/tree/feature-mannycolon-306
- [ ] Verify that both prod (main) and develop version numbers are shown in the markdown
![Screen Shot 2021-11-17 at 10 22 14 AM](https://user-images.githubusercontent.com/17072300/142229639-b9019348-b3ee-4696-9964-b4684dd04d62.png)

