### PR TITLE
Feature kintsoogi 384 lexicon popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "next": "10.2.0",
     "postcss": "^8.2.1",
     "react": "^17.0.2",
+    "react-bootstrap": "0.32.4",
     "react-dom": "^17.0.2",
     "react-draggable": "^4.4.5",
     "react-icons": "^4.8.0",

--- a/src/components/PopoverComponent.js
+++ b/src/components/PopoverComponent.js
@@ -1,10 +1,19 @@
 
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles'
 import Popover from '@mui/material/Popover';
 import Divider from '@mui/material/Divider';
 import { Glyphicon } from 'react-bootstrap';
 import useWindowEvent from '../hooks/useWindowEvent';
+
+const useStyles = makeStyles(() => ({
+  popover: {
+    padding: '0.75em',
+    maxWidth: '400px',
+    backgroundColor: 'var(--background-color-light)',
+  }
+}))
 
 const PopoverComponent = ({
   popoverVisibility,
@@ -13,6 +22,7 @@ const PopoverComponent = ({
   positionCoord,
   onClosePopover,
 }) => {
+  const classes = useStyles();
   const onEscapeKeyPressed = useCallback((e) => {
     if (e.key === 'Escape' || e.keyCode === 27) {
       onClosePopover();
@@ -24,10 +34,7 @@ const PopoverComponent = ({
   return (
     <div>
       <Popover
-        className='popover-root'
-        style={{
-          padding: '0.75em', maxWidth: '400px', backgroundColor: 'var(--background-color-light)',
-        }}
+        classes={{paper: classes.popover}}
         open={popoverVisibility}
         anchorEl={positionCoord}
         anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}

--- a/src/components/PopoverComponent.js
+++ b/src/components/PopoverComponent.js
@@ -4,14 +4,14 @@ import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles'
 import Popover from '@mui/material/Popover';
 import Divider from '@mui/material/Divider';
-import { Glyphicon } from 'react-bootstrap';
+import { IconButton } from '@mui/material'
+import { CgClose } from 'react-icons/cg'
 import useWindowEvent from '../hooks/useWindowEvent';
 
 const useStyles = makeStyles(() => ({
   popover: {
     padding: '0.75em',
     maxWidth: '400px',
-    backgroundColor: 'var(--background-color-light)',
   }
 }))
 
@@ -49,15 +49,20 @@ const PopoverComponent = ({
           }}>
             {title}
           </span>
-          <Glyphicon glyph={'remove'}
+          <IconButton
+            key='lexicon-close-button'
+            onClick={onClosePopover}
+            title={'Close Lexicon'}
+            aria-label={'Close Lexicon'}
             style={{
-              paddingTop: '5px',
-              color: 'var(--text-color-light)',
+              paddingTop: '0px',
               cursor: 'pointer',
               alignItems: 'top',
               marginLeft: 'auto', marginRight: 5,
             }}
-            onClick={onClosePopover} />
+          >
+            <CgClose id='lexicon-close-icon' color='black' />
+          </IconButton>
         </div>
         <Divider />
         <span style={{ padding: '10px 0 15px 0' }}>

--- a/src/components/PopoverComponent.js
+++ b/src/components/PopoverComponent.js
@@ -1,0 +1,72 @@
+
+import React, { useCallback } from 'react';
+import PropTypes from 'prop-types';
+import Popover from '@mui/material/Popover';
+import Divider from '@mui/material/Divider';
+import { Glyphicon } from 'react-bootstrap';
+import useWindowEvent from '../hooks/useWindowEvent';
+
+const PopoverComponent = ({
+  popoverVisibility,
+  title,
+  bodyText,
+  positionCoord,
+  onClosePopover,
+}) => {
+  const onEscapeKeyPressed = useCallback((e) => {
+    if (e.key === 'Escape' || e.keyCode === 27) {
+      onClosePopover();
+    }
+  },[onClosePopover]);
+
+  useWindowEvent('keydown', onEscapeKeyPressed)
+
+  return (
+    <div>
+      <Popover
+        className='popover-root'
+        style={{
+          padding: '0.75em', maxWidth: '400px', backgroundColor: 'var(--background-color-light)',
+        }}
+        open={popoverVisibility}
+        anchorEl={positionCoord}
+        anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
+        transformOrigin={{ horizontal: 'left', vertical: 'top' }}
+        onClose={onClosePopover}
+      >
+        <div style={{
+          display: 'flex', alignItems:'top', padding: 0,
+        }}>
+          <span style={{
+            fontSize: '1.2em', fontWeight: 'bold', marginBottom: 10, marginTop: 0, paddingTop: 0,
+          }}>
+            {title}
+          </span>
+          <Glyphicon glyph={'remove'}
+            style={{
+              paddingTop: '5px',
+              color: 'var(--text-color-light)',
+              cursor: 'pointer',
+              alignItems: 'top',
+              marginLeft: 'auto', marginRight: 5,
+            }}
+            onClick={onClosePopover} />
+        </div>
+        <Divider />
+        <span style={{ padding: '10px 0 15px 0' }}>
+          {bodyText}
+        </span>
+      </Popover>
+    </div>
+  );
+}
+
+PopoverComponent.propTypes = {
+  popoverVisibility: PropTypes.any,
+  title: PropTypes.any,
+  bodyText: PropTypes.any,
+  positionCoord: PropTypes.any,
+  onClosePopover: PropTypes.func,
+};
+
+export default PopoverComponent;

--- a/src/components/WordAlignerDialog.js
+++ b/src/components/WordAlignerDialog.js
@@ -3,10 +3,8 @@ import PropTypes from 'prop-types'
 import Dialog from '@mui/material/Dialog'
 import DialogTitle from '@mui/material/DialogTitle'
 import { RxLink2, RxLinkBreak2 } from 'react-icons/rx'
-import { CgCloseR } from 'react-icons/cg'
 import { WordAligner } from 'word-aligner-rcl'
 import Button from '@mui/material/Button'
-import { IconButton } from '@mui/material'
 import Paper from '@mui/material/Paper'
 import Draggable from 'react-draggable'
 import PopoverComponent from './PopoverComponent'
@@ -134,7 +132,7 @@ export default function WordAlignerDialog({
         popoverVisibility={lexiconData}
         title={lexiconData?.PopoverTitle || ''}
         bodyText={lexiconData?.wordDetails || ''}
-        positionCoord={[]}
+        positionCoord={lexiconData?.positionCoord}
         onClosePopover={() => setLexiconData(null)}
       />
     </>

--- a/src/components/WordAlignerDialog.js
+++ b/src/components/WordAlignerDialog.js
@@ -9,6 +9,7 @@ import Button from '@mui/material/Button'
 import { IconButton } from '@mui/material'
 import Paper from '@mui/material/Paper'
 import Draggable from 'react-draggable'
+import PopoverComponent from './PopoverComponent'
 
 const alignmentIconStyle = { marginLeft:'50px' }
 
@@ -127,31 +128,15 @@ export default function WordAlignerDialog({
           </Button>
         </span>
       </Dialog>
-
+      // TODO: Switch this to the tCore Popover to display on click.
       {/** Lexicon Popup dialog */}
-      <Dialog
-        onClose={() => setLexiconData(null)}
-        open={lexiconData}
-      >
-        <DialogTitle>
-          <div style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>
-            {lexiconData?.PopoverTitle || ''}
-            <IconButton
-              key='lexicon-close-button'
-              onClick={() => setLexiconData(null)}
-              title={'Close Lexicon'}
-              aria-label={'Close Lexicon'}
-              style={{ cursor: 'pointer' }}
-            >
-              <CgCloseR id='lexicon-close-icon' color='black' />
-            </IconButton>
-          </div>
-        </DialogTitle>
-        <hr style={{ borderWidth: 'thin', borderColor: 'lightgray', width: '94%' }} />
-        <div style={{ margin: '10px', marginTop: '0' }}>
-          {lexiconData?.wordDetails || ''}
-        </div>
-      </Dialog>
+      <PopoverComponent
+        popoverVisibility={lexiconData}
+        title={lexiconData?.PopoverTitle || ''}
+        bodyText={lexiconData?.wordDetails || ''}
+        positionCoord={[]}
+        onClosePopover={() => setLexiconData(null)}
+      />
     </>
   )
 }

--- a/src/components/WordAlignerDialog.js
+++ b/src/components/WordAlignerDialog.js
@@ -126,7 +126,6 @@ export default function WordAlignerDialog({
           </Button>
         </span>
       </Dialog>
-      // TODO: Switch this to the tCore Popover to display on click.
       {/** Lexicon Popup dialog */}
       <PopoverComponent
         popoverVisibility={lexiconData}

--- a/src/hooks/useWindowEvent.js
+++ b/src/hooks/useWindowEvent.js
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Takes a type of window event and a callback and attaches and removes it from window.
+ * @param {string} type
+ * @param {function} callback
+ * @returns
+ */
+const useWindowEvent = ({type, callback}) => {
+  useEffect(() => {
+    window.addEventListener(type, callback);
+    return () => {
+      window.removeEventListener(type, callback);
+    };
+  }, [type, callback]);
+
+  window.addEventListener('keydown', onEscapeKeyPressed);
+
+  const onEscapeKeyPressed = (e) => {
+    if (e.key === 'Escape' || e.keyCode === 27) {
+      this.props.onClosePopover();
+    }
+  }
+}
+
+useWindowEvent.propTypes = {
+  type: PropTypes.string,
+  callback: PropTypes.func
+};
+
+export default useWindowEvent;

--- a/src/hooks/useWindowEvent.js
+++ b/src/hooks/useWindowEvent.js
@@ -14,14 +14,6 @@ const useWindowEvent = ({type, callback}) => {
       window.removeEventListener(type, callback);
     };
   }, [type, callback]);
-
-  window.addEventListener('keydown', onEscapeKeyPressed);
-
-  const onEscapeKeyPressed = (e) => {
-    if (e.key === 'Escape' || e.keyCode === 27) {
-      this.props.onClosePopover();
-    }
-  }
 }
 
 useWindowEvent.propTypes = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8821,7 +8821,7 @@ raw-body@2.4.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-bootstrap@^0.32.1:
+react-bootstrap@0.32.4, react-bootstrap@^0.32.1:
   version "0.32.4"
   resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-0.32.4.tgz#8efc4cbfc4807215d75b7639bee0d324c8d740d1"
   integrity sha512-xj+JfaPOvnvr3ow0aHC7Y3HaBKZNR1mm361hVxVzVX3fcdJNIrfiodbQ0m9nLBpNxiKG6FTU2lq/SbTDYT2vew==


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ] Change MUI dialog for the popover component from tCore when clicking on source language Primary Token Word.

## Test Instructions

- [ ] Open the [deployment preview](https://deploy-preview-402--gateway-edit.netlify.app/)  of Gateway Edit
- [ ] Navigate to a verse that has a broken alignment (or add text to break one).
- [ ] Click on the broken alignment icon to pull up the alignment dialog
- [ ] Click on a source word token and verify that the Popup looks similar to the popup from Translation Core (example below)

![Screenshot 2023-04-11 153105](https://user-images.githubusercontent.com/118755839/231282697-720ae0df-df9c-4bbd-9ba6-fe2aa387b6ff.png)
