### PR TITLE
Fixed aligner null data on accept with no changes

### DIFF
--- a/src/components/WordAlignerDialog.js
+++ b/src/components/WordAlignerDialog.js
@@ -74,11 +74,13 @@ export default function WordAlignerDialog({
   function cancelAlignment() {
     const cancelAlignment = alignerStatus?.actions?.cancelAlignment
     cancelAlignment?.()
+    setAlignmentChange(null)
   }
 
   function saveAlignment() {
     const saveAlignment = alignerStatus?.actions?.saveAlignment
     saveAlignment?.(alignmentChange)
+    setAlignmentChange(null)
   }
 
   return (


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ] Fix null verse data after accepting an alignment with no changes

## Test Instructions

- [ ] Verify this bugfix in [this deploy preview](https://deploy-preview-425--gateway-edit.netlify.app/) **v2.0.0 build ee140bd**
- [ ] Open word aligner for a verse, edit alignment, and save (does not matter whether fully aligned or not)
- [ ] Go to another verse or another version (i.e ULT -> UST) and open up the word aligner for a verse (any other verse)
- [ ] Click accept without making ANY changes
- [ ] Verify that verse & alignment data is not null
