### PR TITLE
added a fix to default to qa when localhost or develop link

### DIFF
--- a/cypress/integration/01-app-init.spec.js
+++ b/cypress/integration/01-app-init.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
 describe('App login & initial setup', () => {
   before(() => {
-    cy.visit('/')
+    cy.visit('/?server=prod')
   })
 
   it('Should log in & get to the resource workspace screen successfully', () => {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gateway-edit",
   "version": "1.2.0",
   "scripts": {
-    "dev": "bash -c \"source ./scripts/set-env.sh && next\"",
+    "dev": "bash -c \"source ./scripts/set-env.sh && cross-env NODE_OPTIONS=--max_old_space_size=4096 next\"",
     "build": "bash -c \"source ./scripts/set-env.sh && next build\"",
     "start": "bash -c \"source ./scripts/set-env.sh && next start\"",
     "export": "next export",

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -73,16 +73,6 @@ export default function Layout({
         setServer(server_) // persist server selection in localstorage
         router.push(`/?server=${serverID_}`) // reload page
       }
-    } else {
-      console.log('No server parameter provided, set defaults')
-
-      if ( window.location.href.includes('localhost')
-      || window.location.href.includes('develop')
-      || window.location.href.includes('deploy-preview')
-      ) {
-        console.log('local or develop or preview, defaulting to ',QA_BASE_URL)
-        setServer(QA_BASE_URL) // let this be the default
-      }
     }
   }, [router?.query]) // TRICKY query property not loaded on first pass, so watch for change
 

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -59,6 +59,10 @@ export default function Layout({
   useEffect(() => {
     const params = router?.query
 
+    if ( window.location.href.includes('localhost') || window.location.href.includes('develop') ) {
+      setServer(QA_BASE_URL) // let this be the default
+    }
+
     if (typeof params?.server === 'string') { // if URL param given
       const serverID_ = params.server.toUpperCase() === QA ? QA : PROD
       const server_ = (serverID_ === QA) ? QA_BASE_URL : BASE_URL

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,4 +1,6 @@
-import { useContext, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useContext, useEffect, useMemo, useRef, useState,
+} from 'react'
 import PropTypes from 'prop-types'
 import { AuthenticationContext } from 'gitea-react-toolkit'
 import Header from '@components/Header'
@@ -6,7 +8,9 @@ import Footer from '@components/Footer'
 import Onboarding from '@components/Onboarding'
 import { StoreContext } from '@context/StoreContext'
 import { getBuildId } from '@utils/build'
-import { APP_NAME, BASE_URL, PROD, QA, QA_BASE_URL } from '@common/constants'
+import {
+  APP_NAME, BASE_URL, PROD, QA, QA_BASE_URL,
+} from '@common/constants'
 import useValidateAccountSettings from '@hooks/useValidateAccountSettings'
 import { useRouter } from 'next/router'
 
@@ -59,18 +63,25 @@ export default function Layout({
   useEffect(() => {
     const params = router?.query
 
-    if ( window.location.href.includes('localhost') || window.location.href.includes('develop') ) {
-      setServer(QA_BASE_URL) // let this be the default
-    }
-
     if (typeof params?.server === 'string') { // if URL param given
       const serverID_ = params.server.toUpperCase() === QA ? QA : PROD
+      console.log('Server specified:',params.server)
       const server_ = (serverID_ === QA) ? QA_BASE_URL : BASE_URL
 
       if (server !== server_) {
         console.log(`_app.js - On init switching server to: ${serverID_}, url server param '${params.server}', old server ${server}, reloading page`)
         setServer(server_) // persist server selection in localstorage
         router.push(`/?server=${serverID_}`) // reload page
+      }
+    } else {
+      console.log('No server parameter provided, set defaults')
+
+      if ( window.location.href.includes('localhost')
+      || window.location.href.includes('develop')
+      || window.location.href.includes('deploy-preview')
+      ) {
+        console.log('local or develop or preview, defaulting to ',QA_BASE_URL)
+        setServer(QA_BASE_URL) // let this be the default
       }
     }
   }, [router?.query]) // TRICKY query property not loaded on first pass, so watch for change

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -1,11 +1,12 @@
-import React, { createContext, useState } from 'react'
+import React, { createContext, useEffect, useState } from 'react'
 import localforage from 'localforage'
 import { AuthenticationContextProvider } from 'gitea-react-toolkit'
 import {
   BASE_URL,
+  QA_BASE_URL,
   CLOSE,
   HTTP_GET_MAX_WAIT_TIME,
-  SERVER_KEY,
+  // SERVER_KEY,
   TOKEN_ID,
 } from '@common/constants'
 import {
@@ -14,14 +15,38 @@ import {
   unAuthenticated,
 } from '@utils/network'
 import NetworkErrorPopup from '@components/NetworkErrorPopUp'
-import useLocalStorage from '@hooks/useLocalStorage'
+// import useLocalStorage from '@hooks/useLocalStorage'
 
 export const AuthContext = createContext({})
 
 export default function AuthContextProvider(props) {
   const [authentication, setAuthentication] = useState(null)
   const [networkError, setNetworkError] = useState(null)
-  const [server, setServer] = useLocalStorage(SERVER_KEY, BASE_URL)
+  // Do not persist server settings across logins
+  // const [server, setServer] = useLocalStorage(SERVER_KEY, defaultServer)
+  const [server, setServer] = useState('')
+
+  // note: window is only available on client side, so the below is placed into a hook
+  // hooks only run on client side.
+  useEffect( () => {
+  /*
+    Determine the default value for server here.
+    if non-prod url, then let default be qa; else prod
+  */
+    console.log('URL is:',window.location.href)
+
+    if ( window.location.href.includes('localhost')
+        || window.location.href.includes('develop')
+        || window.location.href.includes('deploy-preview')
+    ) {
+      console.log('local or develop or preview, defaulting to ',QA_BASE_URL)
+      setServer(QA_BASE_URL)
+    } else {
+      console.log('production server, defaulting to ',BASE_URL)
+      setServer(BASE_URL)
+    }
+  }, [] )
+
 
   /**
    * in the case of a network error, process and display error dialog

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -6,7 +6,6 @@ import {
   QA_BASE_URL,
   CLOSE,
   HTTP_GET_MAX_WAIT_TIME,
-  // SERVER_KEY,
   TOKEN_ID,
 } from '@common/constants'
 import {
@@ -15,7 +14,6 @@ import {
   unAuthenticated,
 } from '@utils/network'
 import NetworkErrorPopup from '@components/NetworkErrorPopUp'
-// import useLocalStorage from '@hooks/useLocalStorage'
 
 export const AuthContext = createContext({})
 
@@ -23,7 +21,6 @@ export default function AuthContextProvider(props) {
   const [authentication, setAuthentication] = useState(null)
   const [networkError, setNetworkError] = useState(null)
   // Do not persist server settings across logins
-  // const [server, setServer] = useLocalStorage(SERVER_KEY, defaultServer)
   const [server, setServer] = useState('')
 
   // note: window is only available on client side, so the below is placed into a hook


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ] when no parameter for QA or PROD is provide, let the default be QA if the url is localhost or if it has develop in the url

## Test Instructions

Using `localhost` or the `develop--` link with current code, then clear persisted settings
![image](https://user-images.githubusercontent.com/1289437/235022610-a2dd25aa-169d-4344-9588-89a879111b91.png)

Then refresh screen and after login appears, notice that settings point to 'git.door43.org'

Now with this change do the same thing and notice that it points to `qa.door43.org`

