### PR TITLE
Update single-scripture-rcl version for #546

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "regenerator-runtime": "^0.13.7",
     "resource-workspace-rcl": "2.1.4",
     "scripture-resources-rcl": "5.4.1",
-    "single-scripture-rcl": "3.4.11",
+    "single-scripture-rcl": "3.4.12",
     "tailwindcss": "^2.0.4",
     "tc-ui-toolkit": "5.3.3",
     "translation-helps-rcl": "3.5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10007,10 +10007,10 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
-single-scripture-rcl@3.4.10:
-  version "3.4.10"
-  resolved "https://registry.yarnpkg.com/single-scripture-rcl/-/single-scripture-rcl-3.4.10.tgz#3cfdc602e537ea0298e46ddb680217f336959445"
-  integrity sha512-I5wHSiHN70oTsP6ErU9MxCuM0y1r0+wkhgEmr5tokCjied8SWl4VQaImujSdhe+CoPVQ+3qfZLvu2N7sGI5Tew==
+single-scripture-rcl@3.4.12:
+  version "3.4.12"
+  resolved "https://registry.yarnpkg.com/single-scripture-rcl/-/single-scripture-rcl-3.4.12.tgz#658851af62e304a625a2df7481dcc7a73f97dc4c"
+  integrity sha512-+4Ien4TzzDSUJ3vgeugtYASiKR8+9pUrD0lBMYZTMbR/Z1YugZHHh294QHOCfFgWdTuKk+Ir2KUYr7QC6wAXZw==
   dependencies:
     "@types/react" "^17.0.0"
     "@types/react-dom" "^17.0.0"


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] Fixes scripture not reloading on update from master. [Issue 546](https://app.zenhub.com/workspaces/gatewayedit-5fa302df5c4ec9001f1d5d54/issues/gh/unfoldingword/gateway-edit/546)

## Test Instructions

- [ ] Make edits to a Scripture Card
- [ ] Make to the same resource on another account
- [ ] Update the scripture card changes, verifying that content reloads
