### PR TITLE
feature 524 / added alignment reset and multi-select.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "resource-workspace-rcl": "2.1.4",
     "scripture-resources-rcl": "5.4.1",
     "scripture-tsv": "0.2.0",
-    "single-scripture-rcl": "3.4.14-beta.19",
+    "single-scripture-rcl": "3.4.14",
     "tailwindcss": "^2.0.4",
     "tc-ui-toolkit": "5.3.3",
     "translation-helps-rcl": "3.5.11",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "resource-workspace-rcl": "2.1.4",
     "scripture-resources-rcl": "5.4.1",
     "scripture-tsv": "0.2.0",
-    "single-scripture-rcl": "3.4.14-beta.16",
+    "single-scripture-rcl": "3.4.14-beta.19",
     "tailwindcss": "^2.0.4",
     "tc-ui-toolkit": "5.3.3",
     "translation-helps-rcl": "3.5.11",

--- a/package.json
+++ b/package.json
@@ -52,13 +52,13 @@
     "resource-workspace-rcl": "2.1.4",
     "scripture-resources-rcl": "5.4.1",
     "scripture-tsv": "0.2.0",
-    "single-scripture-rcl": "3.4.13",
+    "single-scripture-rcl": "3.4.14-beta.16",
     "tailwindcss": "^2.0.4",
     "tc-ui-toolkit": "5.3.3",
     "translation-helps-rcl": "3.5.11",
     "use-deep-compare-effect": "^1.3.1",
     "word-aligner": "^1.0.0",
-    "word-aligner-rcl": "1.0.3"
+    "word-aligner-rcl": "1.0.4"
   },
   "devDependencies": {
     "@babel/core": "^7.15.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10031,10 +10031,10 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
-single-scripture-rcl@3.4.14-beta.16:
-  version "3.4.14-beta.16"
-  resolved "https://registry.yarnpkg.com/single-scripture-rcl/-/single-scripture-rcl-3.4.14-beta.16.tgz#b09a0de742020bd0b9d6ffe7a7591415bbb7ce1f"
-  integrity sha512-f/oAORSokBUIiEggJira/1erKoi247cUC5/5wSECKTwmHzKPU98/LYXjdyWILtzS4uhBvBNwxipFwcm8wzpzmA==
+single-scripture-rcl@3.4.14-beta.19:
+  version "3.4.14-beta.19"
+  resolved "https://registry.yarnpkg.com/single-scripture-rcl/-/single-scripture-rcl-3.4.14-beta.19.tgz#07d609c43e910b8f02d64befac1e403285ddda62"
+  integrity sha512-B66kfLzhmONnBWBMmGu+Nj+6PXQxdmD18vC/SDvX2RMcwLqw89BrHoY3umzi+2cWMTfly3ByyAvtS8mlGOtpqg==
   dependencies:
     "@react-hookz/deep-equal" "^1.0.4"
     "@types/react" "^17.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10031,10 +10031,10 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
-single-scripture-rcl@3.4.13:
-  version "3.4.13"
-  resolved "https://registry.yarnpkg.com/single-scripture-rcl/-/single-scripture-rcl-3.4.13.tgz#5ebb7518376a8e368cb48d57e30c9a1227e1fc87"
-  integrity sha512-Oao1Rk6XX9NCzlHqTZkArpwHgCZQFzx6bS2V7dYv2zjkNF6j4ipnVtn8nYcsrg0lmTM7eO110yOxf8X9Be1W2w==
+single-scripture-rcl@3.4.14-beta.16:
+  version "3.4.14-beta.16"
+  resolved "https://registry.yarnpkg.com/single-scripture-rcl/-/single-scripture-rcl-3.4.14-beta.16.tgz#b09a0de742020bd0b9d6ffe7a7591415bbb7ce1f"
+  integrity sha512-f/oAORSokBUIiEggJira/1erKoi247cUC5/5wSECKTwmHzKPU98/LYXjdyWILtzS4uhBvBNwxipFwcm8wzpzmA==
   dependencies:
     "@react-hookz/deep-equal" "^1.0.4"
     "@types/react" "^17.0.0"
@@ -11600,10 +11600,10 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-word-aligner-rcl@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/word-aligner-rcl/-/word-aligner-rcl-1.0.3.tgz#36481c5d6346b85c69203d5e9f1d9fd2ae7fd241"
-  integrity sha512-m4UjunqrHju2ZEkwPezwJ5f6BO0sGi+6FzAQgCn0yGXDHYPiNG5j7cWQGupHZrwrVGCLaWLpygFs9DFu2TojSA==
+word-aligner-rcl@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/word-aligner-rcl/-/word-aligner-rcl-1.0.4.tgz#254bc6b980680827df8e679f26bec4bc05972be0"
+  integrity sha512-uq8mZLLOo18rNqo4MsM4mD9iSSyRH2BwG1+2dqGlNu5A89B6YPii5e6XoN6CMazSA5OQKa3zqtcBftkowe1L/Q==
   dependencies:
     bible-reference-range "^1.1.0"
     file-loader "^6.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10031,10 +10031,10 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
-single-scripture-rcl@3.4.14-beta.19:
-  version "3.4.14-beta.19"
-  resolved "https://registry.yarnpkg.com/single-scripture-rcl/-/single-scripture-rcl-3.4.14-beta.19.tgz#07d609c43e910b8f02d64befac1e403285ddda62"
-  integrity sha512-B66kfLzhmONnBWBMmGu+Nj+6PXQxdmD18vC/SDvX2RMcwLqw89BrHoY3umzi+2cWMTfly3ByyAvtS8mlGOtpqg==
+single-scripture-rcl@3.4.14:
+  version "3.4.14"
+  resolved "https://registry.yarnpkg.com/single-scripture-rcl/-/single-scripture-rcl-3.4.14.tgz#f317c33c0a142e9832342db73c4111926a761752"
+  integrity sha512-0WCEtdT/KGxQFSWBznS5g3wkWaNmmN4aekjjHVke9WYPWXsFOJ49QqKgzYa0PvETSVVKABT9gqLAQ8rm/iiW9g==
   dependencies:
     "@react-hookz/deep-equal" "^1.0.4"
     "@types/react" "^17.0.0"


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ] implements multi-select in alignment wordbank
- [ ] also implements:  https://github.com/unfoldingWord/gateway-edit/issues/569
- [ ] add support for clearing all alignments
- [ ] add support for multiple selections with shift-click

## Test Instructions

- [ ] test with https://deploy-preview-576--gateway-edit.netlify.app
- [ ] test aligner support for clearing all alignments
- [ ] test aligner support for multiple selections in wordbank with shift-click
- [ ] make sure saving still works after resets of alignments