### PR TITLE
upgrades translation-helps-rcl to 3.5.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "single-scripture-rcl": "3.4.15",
     "tailwindcss": "^2.0.4",
     "tc-ui-toolkit": "5.3.3",
-    "translation-helps-rcl": "3.5.12",
+    "translation-helps-rcl": "3.5.13",
     "use-deep-compare-effect": "^1.3.1",
     "word-aligner": "^1.0.0",
     "word-aligner-rcl": "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4287,10 +4287,10 @@ dayjs@^1.10.4:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
   integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
 
-dcs-branch-merger@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/dcs-branch-merger/-/dcs-branch-merger-1.4.0.tgz#8f4f28b9ee5e24ff64687de9a6ee0d8a6f1fba49"
-  integrity sha512-zKchiKN1rd4sUW99u6+HvKDLmHwzumilfcNJR8afkEViEvfgYAUrjPRihLg7y+FK4DtPbBkpicrKTLg7y3KnPw==
+dcs-branch-merger@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/dcs-branch-merger/-/dcs-branch-merger-1.4.1.tgz#57a2819c8189f8f23325eff8bebf4f7c698b2c49"
+  integrity sha512-IJbG5OpZQkxNDYao+T5MOrtVatvzDBGsuEwoZ7kq214OCTwlR+J96ApyamNeg+/i5ZQ8oKa3H4OMM6NFp6s7Zw==
   dependencies:
     path "0.12.7"
 
@@ -10875,16 +10875,16 @@ transform-runtime@0.0.0:
   resolved "https://registry.yarnpkg.com/transform-runtime/-/transform-runtime-0.0.0.tgz#e714d9b69211dd9537939d50e3aa5788c442b85c"
   integrity sha512-PX3vXzO8lucrVm82vZb7BABBLHyMDPGzn9zElHr+DnvtS3JPXtqwB1iTRe+D6iFXYmjtAF3zH7O0Xc5XpLpMEg==
 
-translation-helps-rcl@3.5.12:
-  version "3.5.12"
-  resolved "https://registry.yarnpkg.com/translation-helps-rcl/-/translation-helps-rcl-3.5.12.tgz#e58427750877c72162aa713fba4033b0e79b40de"
-  integrity sha512-uXj4uWrePiSf2F7eYWauVb1+qp5Rjexu2BYkAe7rGJotG9Z4RI6nbbK56mlG+XHGlbnRkLkIGSZJXOdFDpi8AQ==
+translation-helps-rcl@3.5.13:
+  version "3.5.13"
+  resolved "https://registry.yarnpkg.com/translation-helps-rcl/-/translation-helps-rcl-3.5.13.tgz#c1b089c449b1be87fa7d034446dd9c02d48232d3"
+  integrity sha512-uOWggVqzwlXIsAZ61bJSeUE5kO2yDOyRvSuUXl4iecMsGE08X+zBC9QEPYxlLl3k2Y8EKxDy4DbG8qIcOIhMwA==
   dependencies:
     "@gwdevs/extensible-rcl" "^1.0.1"
     "@mui/styled-engine" "npm:@mui/styled-engine-sc@latest"
     axios "^0.27.2"
     bible-reference-range "^1.1.0"
-    dcs-branch-merger "^1.4.0"
+    dcs-branch-merger "1.4.1"
     deep-equal "^2.0.5"
     react-draggable "^4.4.3"
     styled-components "^5.2.1"


### PR DESCRIPTION
This addresses #547.

Testing instructions:

##### Resource Card Merge Button Shows No False Conflicts
- [ ] login to the app
- [ ] edit a resource card 
- [ ] save the change
- [ ] ensure that the merge button show _no red dot_
- [ ] perform the previous two steps a few times

##### DCS Update Enables Resource Card Merge Button
- [ ] go to DCS PR for resource card
- [ ] add a commit to PR (simulates concurrent edits to the same file)
- [ ] in the app, make an edit to the resource card
- [ ] ensure the merge button has _a red dot_
- [ ] refresh app to pull down changes
- [ ] make edit to resource card
- [ ] ensure merge button has _no red dot_

##### Global Merge Button Still Works
- [ ] after the previous testing stage, perform a global merge
