### PR TITLE
fixes build error while building with node >= 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "gateway-edit",
   "version": "2.1.0",
   "scripts": {
-    "dev": "bash -c \"source ./scripts/set-env.sh && cross-env NODE_OPTIONS=--max_old_space_size=4096 next\"",
-    "build": "bash -c \"source ./scripts/set-env.sh && cross-env NODE_OPTIONS=--max_old_space_size=4096 next build\"",
-    "start": "bash -c \"source ./scripts/set-env.sh && cross-env NODE_OPTIONS=--max_old_space_size=4096 next start\"",
+    "dev": "bash -c \"source ./scripts/set-env.sh && next\"",
+    "build": "bash -c \"source ./scripts/set-env.sh && next build\"",
+    "start": "bash -c \"source ./scripts/set-env.sh && next start\"",
     "export": "next export",
     "postinstall": "husky install",
     "increment-build": "bash scripts/increment-build.sh && git add -A",

--- a/scripts/set-env.sh
+++ b/scripts/set-env.sh
@@ -32,3 +32,28 @@ set_env_var $ENV_FILE NEXT_PUBLIC_BUILD_BRANCH $BRANCH
 set_env_var $ENV_FILE NEXT_PUBLIC_BUILD_CONTEXT $CONTEXT
 
 echo "Environment file new contents: $(cat $ENV_FILE)"
+
+function semMajorVersion() {
+  sed -Ee 's/^v([0-9]+)\..*$/\1/'
+}
+
+function nodeOptions() {
+  nodeMajorVersion=$(node --version | semMajorVersion)
+
+  maxOldSpaceSize="--max_old_space_size=4096"
+  openSSLLegacyProvider="--openssl-legacy-provider"
+
+  if [[ $nodeMajorVersion -gt "16" ]]; then
+    echo "$maxOldSpaceSize $openSSLLegacyProvider"
+  else
+    echo "$maxOldSpaceSize"
+  fi
+}
+
+# NOTE: This code and its transcient dependencies will
+# not be needed once we upgrade node verions universally.
+
+# export these variable so that the process executed
+# in the package.json.scripts file will inherit them
+export NODE_OPTIONS="$(nodeOptions)"
+


### PR DESCRIPTION
__This is a temporary fix__

Any machine building with node >= 18 runs into this issue:
https://github.com/unfoldingWord/translation-helps-rcl/issues/121

A localized solution would be to `export NODE_OPTIONS` in the environment which executes `yarn build` in, however this environment is - for some reason - _not copied_ to the process that executes `node` (maybe a `next` thing?). Thus, I am creating this PR so that myself and other developers using a later version of node can build without constantly manually editing the package.json

