### PR TITLE
Increment version of translation-helps-rcl

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gateway-edit",
-  "version": "2.1.0",
+  "version": "2.3.0",
   "scripts": {
     "dev": "bash -c \"source ./scripts/set-env.sh && next\"",
     "build": "bash -c \"source ./scripts/set-env.sh && next build\"",
@@ -55,7 +55,7 @@
     "single-scripture-rcl": "3.4.15",
     "tailwindcss": "^2.0.4",
     "tc-ui-toolkit": "5.3.3",
-    "translation-helps-rcl": "3.5.13",
+    "translation-helps-rcl": "3.5.14",
     "use-deep-compare-effect": "^1.3.1",
     "word-aligner": "^1.0.0",
     "word-aligner-rcl": "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10876,10 +10876,10 @@ transform-runtime@0.0.0:
   resolved "https://registry.yarnpkg.com/transform-runtime/-/transform-runtime-0.0.0.tgz#e714d9b69211dd9537939d50e3aa5788c442b85c"
   integrity sha512-PX3vXzO8lucrVm82vZb7BABBLHyMDPGzn9zElHr+DnvtS3JPXtqwB1iTRe+D6iFXYmjtAF3zH7O0Xc5XpLpMEg==
 
-translation-helps-rcl@3.5.13:
-  version "3.5.13"
-  resolved "https://registry.yarnpkg.com/translation-helps-rcl/-/translation-helps-rcl-3.5.13.tgz#c1b089c449b1be87fa7d034446dd9c02d48232d3"
-  integrity sha512-uOWggVqzwlXIsAZ61bJSeUE5kO2yDOyRvSuUXl4iecMsGE08X+zBC9QEPYxlLl3k2Y8EKxDy4DbG8qIcOIhMwA==
+translation-helps-rcl@3.5.14:
+  version "3.5.14"
+  resolved "https://registry.yarnpkg.com/translation-helps-rcl/-/translation-helps-rcl-3.5.14.tgz#34621839a454b9aed0627f432e692d8e69430389"
+  integrity sha512-hFbeQ3JoEc6JAD4fAPCrpISBGnO1cWzrQDISQRTw0ZB0pFdyItwiHeVcRDLXaEMvDLFozBzFVIOrkkFMUlJkvw==
   dependencies:
     "@gwdevs/extensible-rcl" "^1.0.1"
     "@mui/styled-engine" "npm:@mui/styled-engine-sc@latest"


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] Addreses fix for [Gateway Edit #601](https://github.com/unfoldingWord/gateway-edit/issues/601)
- [ ] Change setItem to only pass in `null` to `setCurrentCheck` if needed values are not string (will be undefined if not present in items)

## Test Instructions

- [ ] Open [Deploy Preview](https://deploy-preview-603--gateway-edit.netlify.app/)
- [ ] Navigate to Habakkuk in unfoldingWord org (some other books did not show the same problem. The race condition did not affect smaller books)
- [ ] Add a new TN that has a reference range (i.e 1:1-3)
  - [ ] Navigate to the newly created note.
  - [ ] Verify that the scripture card panes are showing the verses for the reference range that was input. For example, if you input a reference range of 1:1-3, you should see all three verses in the scripture cards
