### PR TITLE
Bugfix 526 / fix slow text edit behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
     "resource-workspace-rcl": "2.1.4",
     "scripture-resources-rcl": "5.5.9",
     "scripture-tsv": "0.4.0",
-    "single-scripture-rcl": "3.4.20-beta.16",
+    "single-scripture-rcl": "3.4.20-beta.18",
     "tailwindcss": "^2.0.4",
     "tc-ui-toolkit": "5.3.3",
-    "translation-helps-rcl": "3.5.15-beta",
+    "translation-helps-rcl": "3.5.15",
     "use-deep-compare-effect": "^1.3.1",
     "word-aligner": "^1.0.0",
     "word-aligner-rcl": "1.0.4"

--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
     "resource-workspace-rcl": "2.1.4",
     "scripture-resources-rcl": "5.5.9",
     "scripture-tsv": "0.4.0",
-    "single-scripture-rcl": "3.4.17",
+    "single-scripture-rcl": "3.4.20-beta.16",
     "tailwindcss": "^2.0.4",
     "tc-ui-toolkit": "5.3.3",
-    "translation-helps-rcl": "3.5.14",
+    "translation-helps-rcl": "3.5.15-beta",
     "use-deep-compare-effect": "^1.3.1",
     "word-aligner": "^1.0.0",
     "word-aligner-rcl": "1.0.4"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "resource-workspace-rcl": "2.1.4",
     "scripture-resources-rcl": "5.5.9",
     "scripture-tsv": "0.4.0",
-    "single-scripture-rcl": "3.4.20-beta.18",
+    "single-scripture-rcl": "3.4.18",
     "tailwindcss": "^2.0.4",
     "tc-ui-toolkit": "5.3.3",
     "translation-helps-rcl": "3.5.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10032,10 +10032,10 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
-single-scripture-rcl@3.4.20-beta.16:
-  version "3.4.20-beta.16"
-  resolved "https://registry.yarnpkg.com/single-scripture-rcl/-/single-scripture-rcl-3.4.20-beta.16.tgz#283a8728c8c5e9b6bfa26900085e7adb971fca42"
-  integrity sha512-C3WOjDEXHuy5mRWRD8Ea1cQU8oR6QDFrr2K4pQzwtW5aNSW65TePxcNIJXMHu9/7xfytlb1GwSnoFMfmYchF3w==
+single-scripture-rcl@3.4.20-beta.18:
+  version "3.4.20-beta.18"
+  resolved "https://registry.yarnpkg.com/single-scripture-rcl/-/single-scripture-rcl-3.4.20-beta.18.tgz#cb9184665a7509c7eca779fadd2358392b33870e"
+  integrity sha512-A+ECG3tYLi9PJZKS4nc11vWT5Ny6cwCWjO2OPh9MiSfDTIdeicraMSluTjPLUr1vj8ss9qcv/9r46I+2l+kibw==
   dependencies:
     "@react-hookz/deep-equal" "^1.0.4"
     "@types/react" "^17.0.0"
@@ -10868,10 +10868,10 @@ transform-runtime@0.0.0:
   resolved "https://registry.yarnpkg.com/transform-runtime/-/transform-runtime-0.0.0.tgz#e714d9b69211dd9537939d50e3aa5788c442b85c"
   integrity sha512-PX3vXzO8lucrVm82vZb7BABBLHyMDPGzn9zElHr+DnvtS3JPXtqwB1iTRe+D6iFXYmjtAF3zH7O0Xc5XpLpMEg==
 
-translation-helps-rcl@3.5.15-beta:
-  version "3.5.15-beta"
-  resolved "https://registry.yarnpkg.com/translation-helps-rcl/-/translation-helps-rcl-3.5.15-beta.tgz#db978a6a4eccc552665eb78190df72ab728df979"
-  integrity sha512-iUzFGcXaX+n+qNa4azBUc7xTYNOzsK6EUPc6jtn4CtyjLZ6iAEuCzB2WfgfLLkyUbSkaxItd+LmPR+f9XTkACA==
+translation-helps-rcl@3.5.15:
+  version "3.5.15"
+  resolved "https://registry.yarnpkg.com/translation-helps-rcl/-/translation-helps-rcl-3.5.15.tgz#e7e1f2cd4e2c35e6fda36937298aef343ddc1e51"
+  integrity sha512-RbGDhGrKso1G8SlvlP/Nw6yQWesph3qasvZsskW8dCAHyD/X97m/6VVxPetIUeHULIkQuzgomrg87L9wnoflkQ==
   dependencies:
     "@gwdevs/extensible-rcl" "^1.0.1"
     "@mui/styled-engine" "npm:@mui/styled-engine-sc@latest"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10032,10 +10032,10 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
-single-scripture-rcl@3.4.20-beta.18:
-  version "3.4.20-beta.18"
-  resolved "https://registry.yarnpkg.com/single-scripture-rcl/-/single-scripture-rcl-3.4.20-beta.18.tgz#cb9184665a7509c7eca779fadd2358392b33870e"
-  integrity sha512-A+ECG3tYLi9PJZKS4nc11vWT5Ny6cwCWjO2OPh9MiSfDTIdeicraMSluTjPLUr1vj8ss9qcv/9r46I+2l+kibw==
+single-scripture-rcl@3.4.18:
+  version "3.4.18"
+  resolved "https://registry.yarnpkg.com/single-scripture-rcl/-/single-scripture-rcl-3.4.18.tgz#2ae978e8b86f979eb5f06dfbef9b450239c153bf"
+  integrity sha512-pk6YALxsRD04003CTuYZimCq2hU2tMnEQ1tqVSKfXTk2wwndYOl8UnK8A1AXMbAkskhRFMqplWWj+UkO7Ijvrw==
   dependencies:
     "@react-hookz/deep-equal" "^1.0.4"
     "@types/react" "^17.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10032,10 +10032,10 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
-single-scripture-rcl@3.4.17:
-  version "3.4.17"
-  resolved "https://registry.yarnpkg.com/single-scripture-rcl/-/single-scripture-rcl-3.4.17.tgz#365bbf6ac349fdfc839ba646171ff3936533047d"
-  integrity sha512-uJ07dhxxaXVNAsed1SIVT7qLId+59MNvz5RjFUXoYJCXS73XoJnJXrqAgLEjiU7Q1F/+bQAYjFRSkNzKVo9CyQ==
+single-scripture-rcl@3.4.20-beta.16:
+  version "3.4.20-beta.16"
+  resolved "https://registry.yarnpkg.com/single-scripture-rcl/-/single-scripture-rcl-3.4.20-beta.16.tgz#283a8728c8c5e9b6bfa26900085e7adb971fca42"
+  integrity sha512-C3WOjDEXHuy5mRWRD8Ea1cQU8oR6QDFrr2K4pQzwtW5aNSW65TePxcNIJXMHu9/7xfytlb1GwSnoFMfmYchF3w==
   dependencies:
     "@react-hookz/deep-equal" "^1.0.4"
     "@types/react" "^17.0.0"
@@ -10868,10 +10868,10 @@ transform-runtime@0.0.0:
   resolved "https://registry.yarnpkg.com/transform-runtime/-/transform-runtime-0.0.0.tgz#e714d9b69211dd9537939d50e3aa5788c442b85c"
   integrity sha512-PX3vXzO8lucrVm82vZb7BABBLHyMDPGzn9zElHr+DnvtS3JPXtqwB1iTRe+D6iFXYmjtAF3zH7O0Xc5XpLpMEg==
 
-translation-helps-rcl@3.5.14:
-  version "3.5.14"
-  resolved "https://registry.yarnpkg.com/translation-helps-rcl/-/translation-helps-rcl-3.5.14.tgz#34621839a454b9aed0627f432e692d8e69430389"
-  integrity sha512-hFbeQ3JoEc6JAD4fAPCrpISBGnO1cWzrQDISQRTw0ZB0pFdyItwiHeVcRDLXaEMvDLFozBzFVIOrkkFMUlJkvw==
+translation-helps-rcl@3.5.15-beta:
+  version "3.5.15-beta"
+  resolved "https://registry.yarnpkg.com/translation-helps-rcl/-/translation-helps-rcl-3.5.15-beta.tgz#db978a6a4eccc552665eb78190df72ab728df979"
+  integrity sha512-iUzFGcXaX+n+qNa4azBUc7xTYNOzsK6EUPc6jtn4CtyjLZ6iAEuCzB2WfgfLLkyUbSkaxItd+LmPR+f9XTkACA==
   dependencies:
     "@gwdevs/extensible-rcl" "^1.0.1"
     "@mui/styled-engine" "npm:@mui/styled-engine-sc@latest"


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] update single-scripture-rcl with fix for slow verse edit behavior

## Test Instructions

- [ ] test with https://deploy-preview-618--gateway-edit.netlify.app/
- [ ] edit a verse and paste in a large text block
- [ ] then type some more characters and should not see any delays for characters typed in.
- [ ] when you are editing, you should see the save and align buttons grayed out.  If you try clicking on them, you should only see the processing spinner as edit window loses context.  You should not see saving of verse changes or alignment dialog pop up - just the processing spinner.
- [ ] when you leave text edit window, should see spinner when processing new edit text
- [ ] after processing finished, save and alignment button should be re-enabled.
