### PR TITLE
bugfix 419 / add bounds checking for draggable word aligner dialog

### DIFF
--- a/src/context/StoreContext.js
+++ b/src/context/StoreContext.js
@@ -15,7 +15,7 @@ export default function StoreContextProvider(props) {
   /*
     The mergeStatusForCards state contains the merge status to and from the main branch
     for each resource and scripture card. This is used in `useMergeCardsProps` and
-    `useUpdateCardsProps` so that we can tell the user which cards cards are needing merge,
+    `useUpdateCardsProps` so that we can tell the user which cards are needing merge,
     having conflicts, etc. This state is also used to call an app-wide merge to/from main
     branch when the user clicks on the update button in the app header and the merge my work
     button in the hamburger menu.


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ]  added bounds checking for draggable word aligner dialog - made use of useBoundsUpdater() hook in translation-helps-rcl

## Test Instructions

- [ ] test with https://deploy-preview-619--gateway-edit.netlify.app/
- [ ] open alignment dialog and make sure it cannot be dragged off screen such than it cannot be dragged back onto screen
