### PR TITLE
Disable OBS detection by default.

### DIFF
--- a/src/components/WorkspaceContainer.js
+++ b/src/components/WorkspaceContainer.js
@@ -128,6 +128,7 @@ function WorkspaceContainer() {
       greekRepoUrl,
       hebrewRepoUrl,
       mainScreenRef,
+      enableObsSupport,
     },
     actions: {
       logout,
@@ -349,7 +350,7 @@ function WorkspaceContainer() {
 
   useEffect(() => {
     setState( { workspaceReady: false })
-    setObsSupport(true) // default to true until actual determination is made - since this will be smoother if user was last viewing OBS
+    setObsSupport(enableObsSupport) // default to enableObsSupport
 
     /**
      * check for presence of valid OBS repo
@@ -384,7 +385,7 @@ function WorkspaceContainer() {
     }
 
     if (owner && languageId && appRef && server && loggedInUser) {
-      checkForObsRepo()
+      enableObsSupport && checkForObsRepo() // if OBS is enabled, check for OBS repo
 
       /**
        * open the literal bible for current GL to find out which books have content

--- a/src/context/StoreContext.js
+++ b/src/context/StoreContext.js
@@ -1,6 +1,7 @@
 import React, {
   createContext,
   useContext,
+  useEffect,
   useState,
 } from 'react'
 import PropTypes from 'prop-types'
@@ -67,7 +68,12 @@ export default function StoreContextProvider(props) {
   }
 
   const [mainScreenRef, setMainScreenRef] = useState(null)
-  const [obsSupport, setObsSupport] = useState(true) // default to true until actual determination is made - since this will not hurt anything and will be smoother if user was last viewing OBS
+  // this is initially set to off for general users, but to enable for development set flag (<user>_enableObs) to true in local storage
+  const [enableObsSupport, setEnableObsSupport] = useUserLocalStorage(
+    'enableObs',
+    false,
+  )
+  const [obsSupport, setObsSupport] = useState(enableObsSupport) // default to enable state until actual determination is made
   const [lastError, setLastError] = useState(null)
   const [owner, setOwner] = useUserLocalStorage('owner', '')
   const [languageId, setLanguageId] = useUserLocalStorage('languageId', '')
@@ -100,6 +106,14 @@ export default function StoreContextProvider(props) {
     checkUnsavedChanges,
     showSaveChangesPrompt,
   } = useSaveChangesPrompt()
+
+  useEffect(() => {
+    // when enableObsSupport changes state (likely from reading from local storage),
+    //    then set the default value for OBS
+    if (enableObsSupport !== obsSupport) {
+      setObsSupport(enableObsSupport)
+    }
+  }, [enableObsSupport])
 
   function onReferenceChange(bookId, chapter, verse) {
     setQuote(null)
@@ -152,6 +166,7 @@ export default function StoreContextProvider(props) {
       cardsLoadingMerge,
       mergeStatusForCards,
       obsSupport,
+      enableObsSupport,
     },
     actions: {
       logout,


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ] add toggle for enabling OBS into local storage and initialize to false
- [ ] change to only check for OBS when the enable OBS flag is true, otherwise OBS is forced off

## Test Instructions

- [ ] test with https://deploy-preview-635--gateway-edit.netlify.app/
- [ ] OBS should not be shown as option when you select unfoldingword/en
- [ ] to enable OBS detection for development, set flag (<user>_enableObs) to true in local storage and do refresh
