### PR TITLE
Bump version of scripture-tsv to 1.0.3 for 'front' validity for verse

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "regenerator-runtime": "^0.13.7",
     "resource-workspace-rcl": "2.1.4",
     "scripture-resources-rcl": "5.5.9",
-    "scripture-tsv": "1.0.2",
+    "scripture-tsv": "1.0.3",
     "single-scripture-rcl": "3.4.19",
     "tailwindcss": "^2.0.4",
     "tc-ui-toolkit": "5.3.3",

--- a/src/components/ResourceCard.js
+++ b/src/components/ResourceCard.js
@@ -429,7 +429,7 @@ export default function ResourceCard({
         : onTsvAdd(row, chapter, verse, bookId, itemIndex)
 
       handleSaveEdit(tsvsObjectToFileString(newTsvs))
-      setItemIndexPure(itemIndex + 1)
+      if (!!items.length) setItemIndexPure(itemIndex + 1)
     } catch (error) {
       console.error(
         'Input reference in new row is not of type chapter:verse',

--- a/yarn.lock
+++ b/yarn.lock
@@ -9905,10 +9905,10 @@ scripture-resources-rcl@5.5.9:
     word-aligner "^1.0.0"
     xregexp "^4.1.1"
 
-scripture-tsv@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/scripture-tsv/-/scripture-tsv-1.0.2.tgz#337b26ef2e75be16017623e59959b88c23f3f655"
-  integrity sha512-xYjt0FQnmjVjjFhC3iFNIPFQd/byOesk3noirWGE1RpBxDdKb7kaNkPxhwhHNvL3FGHW4BS3HzLklH94LmWYgw==
+scripture-tsv@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/scripture-tsv/-/scripture-tsv-1.0.3.tgz#d7ba50e810fd88c4e17c940303970f7cd833a18c"
+  integrity sha512-rNAEdhV5Ru/05WBmnwilpCJajxx2suEVQ9hHVQJ6LNIpeVH5D0r5wM5XjEeZQa/p2AEAChBvG73r4o7+pLxhsQ==
   dependencies:
     lodash.clonedeep "^4.5.0"
     tsv "^0.2.0"


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ] Bump version of scripture-tsv to 1.0.3 for 'front' validity for verse
- [ ] Fix for #636

## Test Instructions

- [ ] Open [Deploy Preview](https://deploy-preview-639--gateway-edit.netlify.app/)
- [ ] Navigate to Psalms
  - [ ] Click on the Add button in translation notes
  - [ ] Verify that all rows generate as normal
