### PR TITLE
Bugfix 643/Splitting Source Word Fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "autoprefixer": "^10.1.0",
     "bible-reference-rcl": "1.4.0",
     "core-js": "^3.8.3",
-    "deep-diff": "^1.0.2",
     "deep-equal": "^2.0.5",
     "gitea-react-toolkit": "2.4.0",
     "localforage": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gateway-edit",
-  "version": "2.4.1",
+  "version": "2.4.0",
   "engines": {
     "node": ">=18.18.0"
   },

--- a/package.json
+++ b/package.json
@@ -40,9 +40,11 @@
     "autoprefixer": "^10.1.0",
     "bible-reference-rcl": "1.4.0",
     "core-js": "^3.8.3",
+    "deep-diff": "^1.0.2",
     "deep-equal": "^2.0.5",
     "gitea-react-toolkit": "2.4.0",
     "localforage": "^1.9.0",
+    "lodash.clonedeep": "^4.5.0",
     "markdown-translatable": "2.0.3",
     "next": "12",
     "postcss": "^8.2.1",
@@ -61,7 +63,7 @@
     "translation-helps-rcl": "3.6.0",
     "use-deep-compare-effect": "^1.3.1",
     "word-aligner": "^1.0.0",
-    "word-aligner-rcl": "1.0.4"
+    "word-aligner-rcl": "file:.yalc/word-aligner-rcl"
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.11",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "translation-helps-rcl": "3.6.0",
     "use-deep-compare-effect": "^1.3.1",
     "word-aligner": "^1.0.0",
-    "word-aligner-rcl": "1.1.0-beta.16"
+    "word-aligner-rcl": "1.1.0"
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gateway-edit",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "engines": {
     "node": ">=18.18.0"
   },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "translation-helps-rcl": "3.6.0",
     "use-deep-compare-effect": "^1.3.1",
     "word-aligner": "^1.0.0",
-    "word-aligner-rcl": "file:.yalc/word-aligner-rcl"
+    "word-aligner-rcl": "1.1.0-beta.16"
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.11",

--- a/src/components/WordAlignerArea.js
+++ b/src/components/WordAlignerArea.js
@@ -45,17 +45,10 @@ export default function WordAlignerArea({
     const verseAlignments_ = initialAlignment?.verseAlignments;
     const targetWords_ = initialAlignment?.targetWords;
     const changedTW = !isEqual(targetWords, targetWords_);
-    if (changedTW) {
-      // const differences = diff(targetWords, targetWords_);
-      console.log("targetWords differences")
-    }
     const changedVA = !isEqual(verseAlignments, verseAlignments_);
-    if (changedVA) {
-      // const differences = diff(verseAlignments, verseAlignments_);
-      console.log("verseAlignments differences")
-    }
 
     if (changedTW || changedVA) {
+      console.log('WordAlignerArea: alignment data changed')
       const newAlignment = {
         verseAlignments,
         targetWords,

--- a/src/components/WordAlignerArea.js
+++ b/src/components/WordAlignerArea.js
@@ -1,0 +1,100 @@
+import React, {useEffect, useState} from 'react'
+import PropTypes from 'prop-types'
+import DialogTitle from '@mui/material/DialogTitle'
+import { RxLink2, RxLinkBreak2 } from 'react-icons/rx'
+import { AlignmentHelpers, WordAligner } from 'word-aligner-rcl'
+
+// popup dialog for user to align verse
+export default function WordAlignerArea({
+  aligned,
+  alignmentIconStyle,
+  contextId,
+  lexiconCache,
+  loadLexiconEntry,
+  onChange,
+  showPopover,
+  sourceLanguage,
+  sourceLanguageFont,
+  sourceFontSizePercent,
+  targetLanguage,
+  targetLanguageFont,
+  targetFontSizePercent,
+  title,
+  translate,
+  verseAlignments,
+  targetWords,
+  style,
+}) {
+  const [aligned_, setAligned] = useState(aligned)
+  const [alignmentChange, setAlignmentChange] = useState(null)
+
+  useEffect(() => {
+    console.log('WordAlignerArea: initialized')
+  }, [])
+
+  useEffect(() => {
+    if (aligned !== aligned_) {
+      console.log('WordAlignerArea: set alignment to', aligned)
+      setAligned(aligned)
+    }
+  }, [aligned])
+
+
+  function onAlignmentChange(results) {
+    // const onAlignmentsChange = alignerStatus?.actions?.onAlignmentsChange
+    // const alignmentComplete = onAlignmentsChange?.(results)
+    const alignmentComplete = AlignmentHelpers.areAlgnmentsComplete(results.targetWords, results.verseAlignments);
+    setAlignmentChange(results) // save the most recent change
+    setAligned(alignmentComplete) // update alignment complete status
+  }
+
+  return (
+    <>
+      <DialogTitle style={{ cursor: 'move' }} id="draggable-aligner-dialog-title" >
+          <span>
+            {`Aligning: ${title}`}
+            {aligned_? (
+              <RxLink2 style={alignmentIconStyle} id='valid_icon' color='#BBB' />
+            ) : (
+              <RxLinkBreak2 style={alignmentIconStyle} id='invalid_icon' color='#000' />
+            )}
+          </span>
+      </DialogTitle>
+      <div style={{ width : `95%`, margin: '10px' }} >
+        <WordAligner
+          style={style}
+          verseAlignments={verseAlignments}
+          targetWords={targetWords}
+          translate={translate}
+          contextId={contextId}
+          targetLanguage={targetLanguage}
+          targetLanguageFont={targetLanguageFont}
+          sourceLanguage={sourceLanguage}
+          showPopover={showPopover}
+          lexiconCache={lexiconCache}
+          loadLexiconEntry={loadLexiconEntry}
+          onChange={onAlignmentChange}
+        />
+      </div>
+    </>
+  )
+}
+
+WordAlignerArea.propTypes = {
+  aligned: PropTypes.bool,
+  contextId: PropTypes.object.isRequired,
+  lexiconCache: PropTypes.object,
+  loadLexiconEntry: PropTypes.func.isRequired,
+  onChange: PropTypes.func,
+  showPopover: PropTypes.func.isRequired,
+  sourceLanguage: PropTypes.string.isRequired,
+  sourceLanguageFont: PropTypes.string,
+  sourceFontSizePercent: PropTypes.number,
+  targetLanguageFont: PropTypes.string,
+  targetFontSizePercent: PropTypes.number,
+  translate: PropTypes.func.isRequired,
+  title: PropTypes.string,
+  verseAlignments: PropTypes.array.isRequired,
+  targetWords: PropTypes.array.isRequired,
+};
+

--- a/src/components/WordAlignerArea.js
+++ b/src/components/WordAlignerArea.js
@@ -5,16 +5,25 @@ import { RxLink2, RxLinkBreak2 } from 'react-icons/rx'
 import { AlignmentHelpers, WordAligner } from 'word-aligner-rcl'
 import * as isEqual from "deep-equal";
 import cloneDeep from "lodash.clonedeep";
+import Button from "@mui/material/Button";
+import PopoverComponent from "./PopoverComponent";
+import Dialog from "@mui/material/Dialog";
+import {DialogActions, DialogContent, DialogContentText} from "@mui/material";
+import Draggable from "react-draggable";
+import Paper from "@mui/material/Paper";
+
+const alignmentIconStyle = { marginLeft:'50px' }
 
 // popup dialog for user to align verse
 export default function WordAlignerArea({
   aligned,
+  alignmentActions,
   alignmentIconStyle,
   contextId,
+  errorMessage,
   lexiconCache,
   loadLexiconEntry,
   onChange,
-  showPopover,
   sourceLanguage,
   sourceLanguageFont,
   sourceFontSizePercent,
@@ -29,6 +38,9 @@ export default function WordAlignerArea({
 }) {
   const [aligned_, setAligned] = useState(aligned)
   const [alignmentChange, setAlignmentChange] = useState(null)
+  const [lexiconData, setLexiconData] = useState(null)
+  const [showResetWarning, setShowResetWarning] = useState(false)
+  const currentShowDialog = !!(targetWords?.length && verseAlignments?.length)
 
   useEffect(() => {
     console.log('WordAlignerArea: initialized')
@@ -49,19 +61,65 @@ export default function WordAlignerArea({
     setAligned(alignmentComplete) // update alignment complete status
   }
 
+  function cancelAlignment() {
+    console.log('WordAlignerDialog: cancelAlignment')
+    const cancelAlignment = alignmentActions?.cancelAlignment
+    cancelAlignment?.()
+    setAlignmentChange(null)
+  }
+
+  function saveAlignment() {
+    console.log('WordAlignerDialog: saveAlignment')
+    const saveAlignment = alignmentActions?.saveAlignment
+    saveAlignment?.(alignmentChange)
+    setAlignmentChange(null)
+  }
+
+  /**
+   * reset all the alignments
+   */
+  function doReset() {
+    console.log('WordAlignerDialog: doReset')
+    // setShowDialog(false) // momentarily hide the dialog
+    // const alignmentData_ = AlignmentHelpers.resetAlignments(showDialog?.verseAlignments, showDialog?.targetWords)
+    //
+    // const showDialog = true;
+    // const dialogState_ = {
+    //   ...alignmentData_, // merge in reset alignment data
+    //   showDialog,
+    // }
+    //
+    // setDialogState(dialogState_); // this causes word aligner to redraw with empty alignments
+    // setAlignmentChange(cloneDeep(alignmentData_)) // clear the last alignment changes in case user next does save
+  }
+
+  function showPopover(PopoverTitle, wordDetails, positionCoord, rawData) {
+    // TODO: make show popover pretty and fix positioning
+    console.log(`showPopover`, rawData)
+    setLexiconData({
+      PopoverTitle,
+      wordDetails,
+      positionCoord,
+      rawData,
+    })
+  }
+
+
+  const enableResetWarning = (currentShowDialog && showResetWarning);
+
   return (
     <>
-      <DialogTitle style={{ cursor: 'move' }} id="draggable-aligner-dialog-title" >
+      <DialogTitle style={{cursor: 'move'}} id="draggable-aligner-dialog-title">
           <span>
             {`Aligning: ${title}`}
-            {aligned_? (
-              <RxLink2 style={alignmentIconStyle} id='valid_icon' color='#BBB' />
+            {aligned_ ? (
+              <RxLink2 style={alignmentIconStyle} id='valid_icon' color='#BBB'/>
             ) : (
-              <RxLinkBreak2 style={alignmentIconStyle} id='invalid_icon' color='#000' />
+              <RxLinkBreak2 style={alignmentIconStyle} id='invalid_icon' color='#000'/>
             )}
           </span>
       </DialogTitle>
-      <div style={{ width : `95%`, margin: '10px' }} >
+      <div style={{width: `95%`, margin: '10px'}}>
         <WordAligner
           style={style}
           verseAlignments={verseAlignments}
@@ -77,18 +135,58 @@ export default function WordAlignerArea({
           onChange={onAlignmentChange}
         />
       </div>
+      <span style={{width: `95%`, height: '60px', display: 'flex', flexDirection: 'row', justifyContent: 'center'}}>
+          <Button variant="outlined" style={{margin: '10px 100px'}} onClick={cancelAlignment}>
+            Cancel
+          </Button>
+        {!errorMessage && // only show these buttons if there is no error
+          <>
+            <Button variant="outlined" style={{margin: '10px 100px'}} onClick={() => setShowResetWarning(true)}>
+              Reset
+            </Button>
+            <Button variant="outlined" style={{margin: '10px 100px'}} onClick={saveAlignment}>
+              Accept
+            </Button>
+          </>
+        }
+        </span>
+      {/** Lexicon Popup dialog */}
+      <PopoverComponent
+        popoverVisibility={lexiconData}
+        title={lexiconData?.PopoverTitle || ''}
+        bodyText={lexiconData?.wordDetails || ''}
+        positionCoord={lexiconData?.positionCoord}
+        onClosePopover={() => setLexiconData(null)}
+      />
 
+      <Dialog open={enableResetWarning} onClose={() => setShowResetWarning(false)} aria-labelledby="reset-warn-dialog">
+        <DialogTitle id="form-dialog-title">{'Warning'}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {'Are you sure you want to clear all alignments?'}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setShowResetWarning(false)} color="primary">
+            No
+          </Button>
+          <Button onClick={doReset} color="secondary">
+            Yes
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   )
 }
 
 WordAlignerArea.propTypes = {
   aligned: PropTypes.bool,
+  alignmentActions: PropTypes.func,
   contextId: PropTypes.object.isRequired,
+  errorMessage: PropTypes.string,
   lexiconCache: PropTypes.object,
   loadLexiconEntry: PropTypes.func.isRequired,
   onChange: PropTypes.func,
-  showPopover: PropTypes.func.isRequired,
   sourceLanguage: PropTypes.string.isRequired,
   sourceLanguageFont: PropTypes.string,
   sourceFontSizePercent: PropTypes.number,

--- a/src/components/WordAlignerArea.js
+++ b/src/components/WordAlignerArea.js
@@ -29,50 +29,10 @@ export default function WordAlignerArea({
 }) {
   const [aligned_, setAligned] = useState(aligned)
   const [alignmentChange, setAlignmentChange] = useState(null)
-  const alignerData_ =
-    targetWords && verseAlignments
-  ?
-    {
-      targetWords,
-      verseAlignments
-    }
-  :
-      null;
 
   useEffect(() => {
     console.log('WordAlignerArea: initialized')
   }, [])
-
-  useEffect(() => {
-    // see if alignment data has changed
-    const show = alignerData_?.showDialog;
-    const verseAlignments_ = dialogState?.verseAlignments || null;
-    const targetWords_ = dialogState?.targetWords || null;
-    const changedTW = !isEqual(targetWords, targetWords_);
-    if (changedTW) {
-      // const differences = diff(wordBank, targetWords_);
-      console.log("targetWords differences")
-    }
-    const changedVA = !isEqual(verseAlignments_, verseAlignments_);
-    if (changedVA) {
-      // const differences = diff(verseAlignments, verseAlignments_);
-      console.log("verseAlignments differences")
-    }
-    const showDialog = !!(verseAlignments_ && targetWords);
-    const changedShow = (!show !== !showDialog)
-
-    if (changedTW || changedVA || changedShow) {
-      const verseAlignments = cloneDeep(verseAlignments_);
-      const targetWords = cloneDeep(wordBank);
-      setDialogState({
-        verseAlignments,
-        targetWords,
-        showDialog,
-      })
-    }
-
-    setCurrentAlignerData(cloneDeep(alignerData_))
-  }, [alignerData_])
 
   useEffect(() => {
     if (aligned !== aligned_) {
@@ -80,32 +40,6 @@ export default function WordAlignerArea({
       setAligned(aligned)
     }
   }, [aligned])
-
-  useEffect(() => {
-    // see if verse alignment data has changed
-    const alignments_ = verseAlignments || null;
-    const wordBank_ = targetWords || null;
-
-    const changedTW = !isEqual(wordBank_, wordBank);
-    if (changedTW) {
-      // const differences = diff(wordBank, targetWords_);
-      console.log("wordBank differences")
-    }
-    const changedVA = !isEqual(alignments_, verseAlignments_);
-    if (changedVA) {
-      // const differences = diff(verseAlignments, verseAlignments_);
-      console.log("alignments differences")
-    }
-    if (changedTW || changedVA) {
-      const alignments = cloneDeep(alignments_);
-      const wordBank = cloneDeep(wordBank_);
-      setCurrentAlignerData({
-        alignments,
-        wordBank,
-      })
-    }
-  }, [targetWords, verseAlignments,])
-
 
   function onAlignmentChange(results) {
     // const onAlignmentsChange = alignerStatus?.actions?.onAlignmentsChange

--- a/src/components/WordAlignerArea.js
+++ b/src/components/WordAlignerArea.js
@@ -29,10 +29,15 @@ export default function WordAlignerArea({
 }) {
   const [aligned_, setAligned] = useState(aligned)
   const [alignmentChange, setAlignmentChange] = useState(null)
-  const [currentAlignerData, setCurrentAlignerData] = useState(null)
-
-  const alignments = currentAlignerData?.alignments || null;
-  const wordBank = currentAlignerData?.wordBank || null;
+  const alignerData_ =
+    targetWords && verseAlignments
+  ?
+    {
+      targetWords,
+      verseAlignments
+    }
+  :
+      null;
 
   useEffect(() => {
     console.log('WordAlignerArea: initialized')
@@ -40,26 +45,24 @@ export default function WordAlignerArea({
 
   useEffect(() => {
     // see if alignment data has changed
-    const alignments = alignerData_?.alignments || null;
-    const wordBank = alignerData_?.wordBank || null;
     const show = alignerData_?.showDialog;
     const verseAlignments_ = dialogState?.verseAlignments || null;
     const targetWords_ = dialogState?.targetWords || null;
-    const changedTW = !isEqual(wordBank, targetWords_);
+    const changedTW = !isEqual(targetWords, targetWords_);
     if (changedTW) {
       // const differences = diff(wordBank, targetWords_);
       console.log("targetWords differences")
     }
-    const changedVA = !isEqual(alignments, verseAlignments_);
+    const changedVA = !isEqual(verseAlignments_, verseAlignments_);
     if (changedVA) {
       // const differences = diff(verseAlignments, verseAlignments_);
       console.log("verseAlignments differences")
     }
-    const showDialog = !!(alignments && wordBank);
+    const showDialog = !!(verseAlignments_ && targetWords);
     const changedShow = (!show !== !showDialog)
 
     if (changedTW || changedVA || changedShow) {
-      const verseAlignments = cloneDeep(alignments);
+      const verseAlignments = cloneDeep(verseAlignments_);
       const targetWords = cloneDeep(wordBank);
       setDialogState({
         verseAlignments,
@@ -88,7 +91,7 @@ export default function WordAlignerArea({
       // const differences = diff(wordBank, targetWords_);
       console.log("wordBank differences")
     }
-    const changedVA = !isEqual(alignments_, alignments);
+    const changedVA = !isEqual(alignments_, verseAlignments_);
     if (changedVA) {
       // const differences = diff(verseAlignments, verseAlignments_);
       console.log("alignments differences")

--- a/src/components/WordAlignerArea.js
+++ b/src/components/WordAlignerArea.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import DialogTitle from '@mui/material/DialogTitle'
 import { RxLink2, RxLinkBreak2 } from 'react-icons/rx'
 import { AlignmentHelpers, WordAligner } from 'word-aligner-rcl'
+import * as isEqual from "deep-equal";
+import cloneDeep from "lodash.clonedeep";
 
 // popup dialog for user to align verse
 export default function WordAlignerArea({
@@ -16,21 +18,58 @@ export default function WordAlignerArea({
   sourceLanguage,
   sourceLanguageFont,
   sourceFontSizePercent,
+  style,
   targetLanguage,
   targetLanguageFont,
   targetFontSizePercent,
   title,
   translate,
-  verseAlignments,
   targetWords,
-  style,
+  verseAlignments,
 }) {
   const [aligned_, setAligned] = useState(aligned)
   const [alignmentChange, setAlignmentChange] = useState(null)
+  const [currentAlignerData, setCurrentAlignerData] = useState(null)
+
+  const alignments = currentAlignerData?.alignments || null;
+  const wordBank = currentAlignerData?.wordBank || null;
 
   useEffect(() => {
     console.log('WordAlignerArea: initialized')
   }, [])
+
+  useEffect(() => {
+    // see if alignment data has changed
+    const alignments = alignerData_?.alignments || null;
+    const wordBank = alignerData_?.wordBank || null;
+    const show = alignerData_?.showDialog;
+    const verseAlignments_ = dialogState?.verseAlignments || null;
+    const targetWords_ = dialogState?.targetWords || null;
+    const changedTW = !isEqual(wordBank, targetWords_);
+    if (changedTW) {
+      // const differences = diff(wordBank, targetWords_);
+      console.log("targetWords differences")
+    }
+    const changedVA = !isEqual(alignments, verseAlignments_);
+    if (changedVA) {
+      // const differences = diff(verseAlignments, verseAlignments_);
+      console.log("verseAlignments differences")
+    }
+    const showDialog = !!(alignments && wordBank);
+    const changedShow = (!show !== !showDialog)
+
+    if (changedTW || changedVA || changedShow) {
+      const verseAlignments = cloneDeep(alignments);
+      const targetWords = cloneDeep(wordBank);
+      setDialogState({
+        verseAlignments,
+        targetWords,
+        showDialog,
+      })
+    }
+
+    setCurrentAlignerData(cloneDeep(alignerData_))
+  }, [alignerData_])
 
   useEffect(() => {
     if (aligned !== aligned_) {
@@ -38,6 +77,31 @@ export default function WordAlignerArea({
       setAligned(aligned)
     }
   }, [aligned])
+
+  useEffect(() => {
+    // see if verse alignment data has changed
+    const alignments_ = verseAlignments || null;
+    const wordBank_ = targetWords || null;
+
+    const changedTW = !isEqual(wordBank_, wordBank);
+    if (changedTW) {
+      // const differences = diff(wordBank, targetWords_);
+      console.log("wordBank differences")
+    }
+    const changedVA = !isEqual(alignments_, alignments);
+    if (changedVA) {
+      // const differences = diff(verseAlignments, verseAlignments_);
+      console.log("alignments differences")
+    }
+    if (changedTW || changedVA) {
+      const alignments = cloneDeep(alignments_);
+      const wordBank = cloneDeep(wordBank_);
+      setCurrentAlignerData({
+        alignments,
+        wordBank,
+      })
+    }
+  }, [targetWords, verseAlignments,])
 
 
   function onAlignmentChange(results) {
@@ -76,6 +140,7 @@ export default function WordAlignerArea({
           onChange={onAlignmentChange}
         />
       </div>
+
     </>
   )
 }

--- a/src/components/WordAlignerDialog.js
+++ b/src/components/WordAlignerDialog.js
@@ -100,13 +100,6 @@ export default function WordAlignerDialog({
 
   const errorMessage = alignerStatus?.state?.errorMessage
 
-  useEffect(() => { // set initial aligned state
-    if (shouldShowDialog) {
-      console.log('WordAlignerDialog: set initial aligned state')
-      setAligned(!!alignerStatus?.state?.aligned)
-    }
-  }, [shouldShowDialog, alignerStatus])
-
   const {
     projectId,
     chapter,

--- a/src/components/WordAlignerDialog.js
+++ b/src/components/WordAlignerDialog.js
@@ -5,7 +5,6 @@ import React, {
   useState,
 } from 'react'
 import PropTypes from 'prop-types'
-import cloneDeep from 'lodash.clonedeep'
 import Dialog from '@mui/material/Dialog'
 import Paper from '@mui/material/Paper'
 import Draggable from 'react-draggable'
@@ -21,12 +20,11 @@ export default function WordAlignerDialog({
   getLexiconData,
 }) {
   const [aligned, setAligned] = useState(false)
-  const [dialogState, setDialogState_] = useState({})
+  const [showDialog, setShowDialog] = useState({})
   const dialogRef = useRef(null) // for keeping track of  aligner dialog position
 
   const alignerData_ = alignerStatus?.state?.alignerData || null
   const shouldShowDialog = !!(alignerData_?.alignments && alignerData_?.wordBank)
-  const currentShowDialog = !!dialogState?.showDialog
 
   const {
     state: {
@@ -37,9 +35,9 @@ export default function WordAlignerDialog({
   const boundsParams = { // keeps track of drag bounds
     workspaceRef: mainScreenRef,
     cardRef: dialogRef,
-    open: !!currentShowDialog,
+    open: !!showDialog,
     displayState: {
-      alignerData: currentShowDialog
+      alignerData: showDialog
     },
   };
   const {
@@ -63,13 +61,9 @@ export default function WordAlignerDialog({
 
   useEffect(() => {
     console.log('WordAlignerDialog: aligner data changed')
-    if (currentShowDialog !== shouldShowDialog) {
+    if (showDialog !== shouldShowDialog) {
       console.log('WordAlignerDialog: aligner visible state changed')
-      const dialogState_ = {
-        ...alignerData_,
-        showDialog: shouldShowDialog,
-      };
-      setDialogState(dialogState_)
+      setShowDialog(shouldShowDialog)
     }
   }, [alignerData_])
 
@@ -107,23 +101,13 @@ export default function WordAlignerDialog({
   } = alignerStatus?.state?.reference || {}
   const title = `${projectId?.toUpperCase()} ${chapter}:${verse} in ${alignerStatus?.state?.title}`
 
-  function setDialogState(newState) {
-    const dialogState_ = cloneDeep(
-      {
-        ...dialogState,
-        ...newState,
-      }
-    )
-    setDialogState_(dialogState_)
-  }
-
   return (
     <>
       <Dialog
         fullWidth={true}
         maxWidth={'lg'}
         onClose={() => {}}
-        open={!!currentShowDialog}
+        open={!!showDialog}
         PaperComponent={PaperComponent}
         bounds={bounds}
         aria-labelledby="draggable-aligner-dialog-title"
@@ -134,8 +118,8 @@ export default function WordAlignerDialog({
           errorMessage={errorMessage}
           title={title || ''}
           style={{ maxHeight: `${height}px`, overflowY: 'auto' }}
-          verseAlignments={dialogState?.alignments || []}
-          targetWords={dialogState?.wordBank || []}
+          verseAlignments={alignerData_?.alignments || []}
+          targetWords={alignerData_?.wordBank || []}
           translate={translate}
           contextId={{ reference: alignerStatus?.state?.reference || {} }}
           targetLanguage={alignerStatus?.state?.targetLanguage || ''}

--- a/src/components/WordAlignerDialog.js
+++ b/src/components/WordAlignerDialog.js
@@ -34,13 +34,12 @@ export default function WordAlignerDialog({
   const [alignmentChange, setAlignmentChange] = useState(null)
   const [aligned, setAligned] = useState(false)
   const [lexiconData, setLexiconData] = useState(null)
-  const [dialogState, setDialogState] = useState(false)
+  const [dialogState, setDialogState_] = useState({})
   const [showResetWarning, setShowResetWarning] = useState(false)
   const dialogRef = useRef(null) // for keeping track of  aligner dialog position
 
   const alignerData_ = alignerStatus?.state?.alignerData || null
-  const shouldShowDialog = !!(alignerData_?.verseAlignments && alignerData_?.targetWords)
-
+  const shouldShowDialog = !!(alignerData_?.alignments && alignerData_?.wordBank)
   const currentShowDialog = !!dialogState?.showDialog
 
   const {
@@ -80,11 +79,11 @@ export default function WordAlignerDialog({
     console.log('WordAlignerDialog: aligner data changed')
     if (currentShowDialog !== shouldShowDialog) {
       console.log('WordAlignerDialog: aligner visible state changed')
-      setShowDialog(shouldShowDialog)
-      setDialogState(cloneDeep({
+      const dialogState_ = {
         ...alignerData_,
         showDialog: shouldShowDialog,
-      }))
+      };
+      setDialogState(dialogState_)
     }
   }, [alignerData_])
 
@@ -102,11 +101,6 @@ export default function WordAlignerDialog({
       </Draggable>
     )
   }
-
-
-  useEffect(() => {
-    console.log('WordAlignerDialog: initialized')
-  }, [])
 
   const currentInstance = dialogRef?.current;
   useEffect(() => { // monitor changes in alignment dialog position and open state
@@ -157,6 +151,15 @@ export default function WordAlignerDialog({
   } = alignerStatus?.state?.reference || {}
   const title = `${projectId?.toUpperCase()} ${chapter}:${verse} in ${alignerStatus?.state?.title}`
 
+  function setDialogState(newState) {
+    const dialogState_ = cloneDeep(
+      {
+        ...dialogState,
+        ...newState,
+      }
+    )
+    setDialogState_(dialogState_)
+  }
   function cancelAlignment() {
     console.log('WordAlignerDialog: cancelAlignment')
     const cancelAlignment = alignerStatus?.actions?.cancelAlignment
@@ -174,10 +177,9 @@ export default function WordAlignerDialog({
   function setShowDialog(show) {
     console.log('WordAlignerDialog: setShowDialog', show)
     const _dialogState = {
-      ...dialogState,
       showDialog: !!show,
     }
-    setDialogState(cloneDeep(_dialogState));
+    setDialogState(_dialogState);
   }
 
   /**
@@ -190,12 +192,11 @@ export default function WordAlignerDialog({
 
     const showDialog = true;
     const dialogState_ = {
-      ...dialogState, // keep old data
       ...alignmentData_, // merge in reset alignment data
       showDialog,
     }
 
-    setDialogState(cloneDeep(dialogState_)); // this causes word aligner to redraw with empty alignments
+    setDialogState(dialogState_); // this causes word aligner to redraw with empty alignments
     setAlignmentChange(cloneDeep(alignmentData_)) // clear the last alignment changes in case user next does save
   }
 
@@ -217,8 +218,8 @@ export default function WordAlignerDialog({
           alignmentIconStyle={alignmentIconStyle}
           title={title || ''}
           style={{ maxHeight: `${height}px`, overflowY: 'auto' }}
-          verseAlignments={dialogState?.verseAlignments || []}
-          targetWords={dialogState?.targetWords || []}
+          verseAlignments={dialogState?.alignments || []}
+          targetWords={dialogState?.wordBank || []}
           translate={translate}
           contextId={{ reference: alignerStatus?.state?.reference || {} }}
           targetLanguage={alignerStatus?.state?.targetLanguage || ''}

--- a/src/components/WordAlignerDialog.js
+++ b/src/components/WordAlignerDialog.js
@@ -34,7 +34,6 @@ export default function WordAlignerDialog({
   translate,
   getLexiconData,
 }) {
-  const [currentAlignerData, setCurrentAlignerData] = useState(null)
   const [alignmentChange, setAlignmentChange] = useState(null)
   const [aligned, setAligned] = useState(false)
   const [lexiconData, setLexiconData] = useState(null)
@@ -43,6 +42,7 @@ export default function WordAlignerDialog({
   const dialogRef = useRef(null) // for keeping track of  aligner dialog position
 
   const alignerData_ = alignerStatus?.state?.alignerData
+  const showDialog = !!(alignerData_?.alignments && alignerData_?.wordBank)
 
   const {
     state: {
@@ -56,9 +56,9 @@ export default function WordAlignerDialog({
   } = useBoundsUpdater({ // keeps track of drag bounds
     workspaceRef: mainScreenRef,
     cardRef: dialogRef,
-    open: !!currentAlignerData,
+    open: !!showDialog,
     displayState: {
-      alignerData: currentAlignerData
+      alignerData: alignerData_
     },
   })
 
@@ -77,50 +77,18 @@ export default function WordAlignerDialog({
     )
   }
 
-  useEffect(() => {
-    // see if alignment data has changed
-    const alignments = alignerData_?.alignments || null;
-    const wordBank = alignerData_?.wordBank || null;
-    const show = alignerData_?.showDialog;
-    const verseAlignments_ = dialogState?.verseAlignments || null;
-    const targetWords_ = dialogState?.targetWords || null;
-    const changedTW = !isEqual(wordBank, targetWords_);
-    if (changedTW) {
-      // const differences = diff(wordBank, targetWords_);
-      console.log("targetWords differences")
-    }
-    const changedVA = !isEqual(alignments, verseAlignments_);
-    if (changedVA) {
-      // const differences = diff(verseAlignments, verseAlignments_);
-      console.log("verseAlignments differences")
-    }
-    const showDialog = !!(alignments && wordBank);
-    const changedShow = (!show !== !showDialog)
-
-    if (changedTW || changedVA || changedShow) {
-      const verseAlignments = cloneDeep(alignments);
-      const targetWords = cloneDeep(wordBank);
-      setDialogState({
-        verseAlignments,
-        targetWords,
-        showDialog,
-      })
-    }
-
-    setCurrentAlignerData(cloneDeep(alignerData_))
-  }, [alignerData_])
 
   useEffect(() => {
     console.log('WordAlignerDialog: initialized')
   }, [])
 
   useEffect(() => { // monitor changes in alignment dialog position and open state
-    if (currentAlignerData &&
+    if (alignerData_ &&
       dialogRef?.current?.clientWidth &&
       dialogRef?.current?.clientHeight) {
       doUpdateBounds()
     }
-  }, [dialogRef?.current, currentAlignerData])
+  }, [dialogRef?.current, alignerData_])
 
   /**
    * called on every alignment change.  We save this new alignment state so that it can be applied if user clicks accept.
@@ -203,9 +171,7 @@ export default function WordAlignerDialog({
     setAlignmentChange(alignmentChange_) // clear the last alignment changes in case user next does save
   }
 
-  const showDialog = !!dialogState?.showDialog;
-  const haveAlignerData = !!(dialogState?.verseAlignments && dialogState?.targetWords)
-  const enableResetWarning = useMemo( () => (showDialog && haveAlignerData), [showDialog, haveAlignerData])
+  const enableResetWarning = false; // useMemo( () => (showDialog && haveAlignerData), [showDialog, haveAlignerData])
 
   return (
     <>
@@ -221,15 +187,15 @@ export default function WordAlignerDialog({
         <WordAlignerArea
           aligned={!!alignerStatus?.state?.aligned}
           alignmentIconStyle={alignmentIconStyle}
-          title={title}
+          title={title || ''}
           style={{ maxHeight: `${height}px`, overflowY: 'auto' }}
-          verseAlignments={dialogState?.verseAlignments}
-          targetWords={dialogState?.targetWords}
+          verseAlignments={dialogState?.verseAlignments || []}
+          targetWords={dialogState?.targetWords || []}
           translate={translate}
           contextId={{ reference: alignerStatus?.state?.reference || {} }}
-          targetLanguage={alignerStatus?.state?.targetLanguage}
+          targetLanguage={alignerStatus?.state?.targetLanguage || ''}
           targetLanguageFont={''}
-          sourceLanguage={alignerStatus?.state?.sourceLanguage}
+          sourceLanguage={alignerStatus?.state?.sourceLanguage || ''}
           showPopover={showPopover}
           lexiconCache={{}}
           loadLexiconEntry={getLexiconData}

--- a/src/components/WordAlignerDialog.js
+++ b/src/components/WordAlignerDialog.js
@@ -7,22 +7,11 @@ import React, {
 import PropTypes from 'prop-types'
 import cloneDeep from 'lodash.clonedeep'
 import Dialog from '@mui/material/Dialog'
-import DialogTitle from '@mui/material/DialogTitle'
-import { AlignmentHelpers } from 'word-aligner-rcl'
-import Button from '@mui/material/Button'
 import Paper from '@mui/material/Paper'
 import Draggable from 'react-draggable'
-import {
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-} from '@mui/material'
 import { useBoundsUpdater } from 'translation-helps-rcl'
-import PopoverComponent from './PopoverComponent'
 import { StoreContext } from '@context/StoreContext'
 import WordAlignerArea from './WordAlignerArea';
-
-const alignmentIconStyle = { marginLeft:'50px' }
 
 // popup dialog for user to align verse
 export default function WordAlignerDialog({
@@ -31,7 +20,6 @@ export default function WordAlignerDialog({
   translate,
   getLexiconData,
 }) {
-  const [alignmentChange, setAlignmentChange] = useState(null)
   const [aligned, setAligned] = useState(false)
   const [dialogState, setDialogState_] = useState({})
   const dialogRef = useRef(null) // for keeping track of  aligner dialog position
@@ -110,18 +98,6 @@ export default function WordAlignerDialog({
     }
   }, [currentInstance, alignerData_])
 
-  /**
-   * called on every alignment change.  We save this new alignment state so that it can be applied if user clicks accept.
-   *   We also update the aligned status so that the UI can be updated dynamically
-   * @param {object} results
-   */
-  function onAlignmentChange(results) {
-    console.log('WordAlignerDialog: onAlignmentChange')
-    const alignmentComplete = AlignmentHelpers.areAlgnmentsComplete(results?.targetWords, results?.verseAlignments);
-    setAlignmentChange(results) // save the most recent change
-    setAligned(alignmentComplete) // update alignment complete status
-  }
-
   const errorMessage = alignerStatus?.state?.errorMessage
 
   useEffect(() => { // set initial aligned state
@@ -148,14 +124,6 @@ export default function WordAlignerDialog({
     setDialogState_(dialogState_)
   }
 
-  function setShowDialog(show) {
-    console.log('WordAlignerDialog: setShowDialog', show)
-    const _dialogState = {
-      showDialog: !!show,
-    }
-    setDialogState(_dialogState);
-  }
-
   return (
     <>
       <Dialog
@@ -170,7 +138,6 @@ export default function WordAlignerDialog({
         <WordAlignerArea
           aligned={aligned}
           alignmentActions={alignerStatus?.actions}
-          alignmentIconStyle={alignmentIconStyle}
           errorMessage={errorMessage}
           title={title || ''}
           style={{ maxHeight: `${height}px`, overflowY: 'auto' }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3796,11 +3796,6 @@ dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==
 
-deep-diff@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-1.0.2.tgz#afd3d1f749115be965e89c63edc7abb1506b9c26"
-  integrity sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==
-
 deep-equal@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
@@ -11105,10 +11100,10 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-word-aligner-rcl@1.1.0-beta.16:
-  version "1.1.0-beta.16"
-  resolved "https://registry.yarnpkg.com/word-aligner-rcl/-/word-aligner-rcl-1.1.0-beta.16.tgz#7131f1373935b034ecb1ca0ef930dd0d52f9bafe"
-  integrity sha512-3Y+fw8XcHVqrbjHoqVwwAsz6vpylXGhM5PHaHdVvniobCkOtM5Ub+I19+QtAC2xyFnGBa6fUEK6QHRjq5Pxj2A==
+word-aligner-rcl@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/word-aligner-rcl/-/word-aligner-rcl-1.1.0.tgz#45e1d1fb0c6de9941f4dc394accd4a829df095ee"
+  integrity sha512-BSdYnxuNrc1jwm6auV8aFT3zkbp2RScVPrpSA3GNwek8hzxi0kLXGwioQg1U6ztrt3i45yF42CtkSRVZXBesRg==
   dependencies:
     bible-reference-range "^1.1.0"
     deep-equal "^2.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3796,6 +3796,11 @@ dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==
 
+deep-diff@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-1.0.2.tgz#afd3d1f749115be965e89c63edc7abb1506b9c26"
+  integrity sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==
+
 deep-equal@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
@@ -11100,14 +11105,14 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-word-aligner-rcl@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/word-aligner-rcl/-/word-aligner-rcl-1.0.4.tgz#254bc6b980680827df8e679f26bec4bc05972be0"
-  integrity sha512-uq8mZLLOo18rNqo4MsM4mD9iSSyRH2BwG1+2dqGlNu5A89B6YPii5e6XoN6CMazSA5OQKa3zqtcBftkowe1L/Q==
+"word-aligner-rcl@file:.yalc/word-aligner-rcl":
+  version "1.1.0-beta.10"
   dependencies:
     bible-reference-range "^1.1.0"
+    deep-diff "^1.0.2"
+    deep-equal "^2.0.5"
     file-loader "^6.2.0"
-    lodash "^4.17.21"
+    lodash.clonedeep "^4.5.0"
     string-punctuation-tokenizer "2.2.0"
     usfm-js "3.4.2"
     word-aligner "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11105,11 +11105,12 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-"word-aligner-rcl@file:.yalc/word-aligner-rcl":
-  version "1.1.0-beta.10"
+word-aligner-rcl@1.1.0-beta.16:
+  version "1.1.0-beta.16"
+  resolved "https://registry.yarnpkg.com/word-aligner-rcl/-/word-aligner-rcl-1.1.0-beta.16.tgz#7131f1373935b034ecb1ca0ef930dd0d52f9bafe"
+  integrity sha512-3Y+fw8XcHVqrbjHoqVwwAsz6vpylXGhM5PHaHdVvniobCkOtM5Ub+I19+QtAC2xyFnGBa6fUEK6QHRjq5Pxj2A==
   dependencies:
     bible-reference-range "^1.1.0"
-    deep-diff "^1.0.2"
     deep-equal "^2.0.5"
     file-loader "^6.2.0"
     lodash.clonedeep "^4.5.0"


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ] updated wordaligner-rcl with fix for unalign target word callback 
- [ ] moved much of the Components from WordAlignerDialog to WordAlignerArea so state changes don't cause rerendering and lost of alignment changes.

## Test Instructions

- [ ] test with this build: https://deploy-preview-648--gateway-edit.netlify.app/
- [ ] in word aligner, try splitting/merging alignments and accepting changes - then reopen to make sure changes persisted
