### PR TITLE
Update translation-helps-rcl to version 3.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "single-scripture-rcl": "3.4.23",
     "tailwindcss": "^2.0.4",
     "tc-ui-toolkit": "5.3.3",
-    "translation-helps-rcl": "3.6.3",
+    "translation-helps-rcl": "3.6.4",
     "use-deep-compare-effect": "^1.3.1",
     "word-aligner": "^1.0.0",
     "word-aligner-rcl": "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10376,10 +10376,10 @@ transform-runtime@0.0.0:
   resolved "https://registry.yarnpkg.com/transform-runtime/-/transform-runtime-0.0.0.tgz#e714d9b69211dd9537939d50e3aa5788c442b85c"
   integrity sha512-PX3vXzO8lucrVm82vZb7BABBLHyMDPGzn9zElHr+DnvtS3JPXtqwB1iTRe+D6iFXYmjtAF3zH7O0Xc5XpLpMEg==
 
-translation-helps-rcl@3.6.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/translation-helps-rcl/-/translation-helps-rcl-3.6.3.tgz#70f4231d5e0e112a0baef58fd09437c9e0b4a533"
-  integrity sha512-KBtoyZ8LzbJ+H2CG9Kaj1JX5yZnrr0XZbsTRDErEzgQMcJ5Hs4Cp5CTddnOQZJQ4xi7NaVVNJBQ88EE0FPQhxA==
+translation-helps-rcl@3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/translation-helps-rcl/-/translation-helps-rcl-3.6.4.tgz#2288c67f6dd5d094ba3038202ebb0779ff3a3a1a"
+  integrity sha512-SNnBl9SFi7qHo6Yo7C3x0gdVcWyPKGPWEWP054BeSen1ewNZ/aA+jTVlCGRjJzwk1BH6Owq50QJUxM1Kn7tfKA==
   dependencies:
     "@gwdevs/extensible-rcl" "^1.0.1"
     "@mui/styled-engine" "npm:@mui/styled-engine-sc@latest"


### PR DESCRIPTION
# Describe what your pull request addresses

The new update of translation-helps-rcl fixes duplicated PRs and avoid new line characters to be inserted in TSV quote fields.

## Test Instructions

- [ ]
