### PR TITLE
Bump package version to 2.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gateway-edit",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "engines": {
     "node": ">=18.18.0"
   },


### PR DESCRIPTION
# Describe what your pull request addresses

 Just bumps the version of gE from 2.4.1 to 2.4.2 prior to release.

## Test Instructions

- [ ]
