### PR TITLE
Catalog URL fix: changes to actual DCS catalog API version and parame…

### DIFF
--- a/src/utils/resources.js
+++ b/src/utils/resources.js
@@ -163,7 +163,7 @@ export function getResourceMessage(resourceStatus, owner, languageId, resourceId
  * @return {Promise<*>}
  */
 export async function getLatestBibleRepo(server, org, lang, bible, processError) {
-  const url = `${server}/api/v1/catalog/search/?owner=${org}&repo=${lang}_${bible}`
+  const url = `${server}/api/v1/catalog/search/?owner=${org}&repo=${lang}_${bible}&metadataType=rc`
   const results = await doFetch(url, {}, HTTP_GET_MAX_WAIT_TIME)
     .then(response => {
       if (response?.status !== 200) {


### PR DESCRIPTION
This is to fix something we have to constantly redirect on the DCS server and almost forgot to in the latest updated. The URL 

https://git.door43.org/api/catalog/v5/search/unfoldingWord/en_tn gets rewritten as:

https://git.door43.org/api/v1/catalog/search?owner=unfoldingWord&repo=en_tn&metadataType=rc

You can verify this new URL format works. 

NOTE: The metadataType=rc is also something to ensure apps that called the old URL only get RC containers as `sb` `ts` and `tc` repos were added to the catalog after the old v5 URL was retired.