### PR TITLE
Fix 500 error on branch save: move dontCreateBranch into config object

### DIFF
--- a/src/components/ResourceCard.jsx
+++ b/src/components/ResourceCard.jsx
@@ -350,13 +350,13 @@ export default function ResourceCard({
       ...authentication?.config,
       token: authentication?.token,
       timeout: SERVER_MAX_WAIT_TIME_RETRY,
+      dontCreateBranch: true,
     },
     author: loggedInUser,
     token: authentication?.token,
     branch: workingResourceBranch,
     filepath: editFilePath,
     repo: `${languageId}_${cardResourceId}`,
-    dontCreateBranch: true,
   })
 
   useEffect(() => { // when we get a save saveError
@@ -443,7 +443,7 @@ export default function ResourceCard({
       const branch = await startEdit()
 
       if (branch) {
-        saveEdit(branch, newContent)
+        await saveEdit(branch, newContent)
       } else { // if error on branch creation
         console.warn(`ResourceCard() handleSaveEdit() error creating edit branch`, { sha, resource })
         onResourceError && onResourceError(null, false, null, `Error creating edit branch ${languageId}_${resourceId}`, true)


### PR DESCRIPTION
The `dontCreateBranch: true` flag was passed as a separate prop to `useEdit`, but `useEdit` only forwards the `config` object to `updateContent()`, where `config.dontCreateBranch` is actually checked. Since it wasn't inside `config`, it was always undefined, causing the save fallback to attempt creating a branch that already exists — triggering an HTTP 500 from the Gitea API.

Also adds missing `await` on `saveEdit()` call during branch creation to prevent race conditions.

Closes #804

# Describe what your pull request addresses

- [x] Fixes HTTP 500 error when saving to user branch caused by `dontCreateBranch` not being correctly passed inside the `config` object to `useEdit`/`updateContent()`
- [x] Adds missing `await` on `saveEdit()` during branch creation to prevent race conditions

## Test Instructions

- [ ] Open a translation note card on a branch that already exists
- [ ] Trigger a Card To Merge / merge from master scenario
- [ ] Attempt to save — verify no HTTP 500 occurs and the save completes successfully