### PR TITLE
Close alignment panel with Escape key

### DIFF
--- a/src/components/WordAlignerDialog.jsx
+++ b/src/components/WordAlignerDialog.jsx
@@ -266,6 +266,17 @@ function WordAlignerDialog({
     }
   } = alignmentSuggestionsManage; // type is TUseAlignmentSuggestionsReturn
 
+  useEffect(() => { // close dialog on Escape key
+    if (!showDialog) return;
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        alignmentActions_?.cancelAlignment();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [showDialog, alignmentActions_]);
+
   useEffect(() => {
     if (shouldShowDialog_ !== showDialog) {
       console.log(`WordAlignerDialog: alignment data changed shouldShowDialog_ ${shouldShowDialog_}`)
@@ -343,7 +354,7 @@ function WordAlignerDialog({
       <Dialog
         fullWidth={true}
         maxWidth={'lg'}
-        onClose={() => {}}
+        onClose={() => alignmentActions_?.cancelAlignment()}
         open={!!showDialog}
         PaperComponent={PaperComponent}
         bounds={bounds}
@@ -378,6 +389,7 @@ function WordAlignerDialog({
     )
   },
   [
+    alignmentActions_,
     contextId,
     errorMessage,
     showDialog,


### PR DESCRIPTION
Closes unfoldingWord/gateway-edit#813

## What this addresses
- Pressing `Escape` while the alignment panel is open now closes it, equivalent to clicking Cancel

## Changes
- Added a `keydown` event listener in `WordAlignerDialog` that calls `cancelAlignment()` on Escape while the dialog is shown
- Updated MUI Dialog's `onClose` (previously a no-op) to also call `cancelAlignment()`, consistent with the Escape key behavior

## Test Instructions
- [ ] Open the alignment panel by clicking the alignment icon on a verse
- [ ] Press `Escape` — panel should close without saving changes
- [ ] Verify it behaves identically to clicking the Cancel button
