### PR TITLE
feat: persist layout preferences to DCS server account (survives incognito)

### DIFF
--- a/src/context/StoreContext.jsx
+++ b/src/context/StoreContext.jsx
@@ -11,6 +11,7 @@ import * as useULS from '@hooks/useUserLocalStorage'
 import { AuthContext } from '@context/AuthContext'
 import useSaveChangesPrompt from '@hooks/useSaveChangesPrompt'
 import { testForMergeError } from "@utils/merge";
+import { getServerLayout, saveServerLayout } from '@utils/serverPreferences'
 
 export const StoreContext = createContext({})
 
@@ -111,6 +112,7 @@ export default function StoreContextProvider(props) {
   const [mergeCheck, setMergeCheck] = useState(0)
   const [authError, setAuthError] = useState(0)
   const transtateRef = useRef(null)
+  const layoutSaveTimerRef = useRef(null)
 
   function translate(key, options) {
     if (transtateRef.current) {
@@ -142,6 +144,29 @@ export default function StoreContextProvider(props) {
       setObsSupport(enableObsSupport)
     }
   }, [enableObsSupport])
+
+  // On login, load layout from server so it survives incognito sessions and cache clears.
+  // localStorage remains the instant fallback; server value wins when available.
+  useEffect(() => {
+    if (authentication) {
+      getServerLayout(server, authentication).then(serverLayout => {
+        if (serverLayout) {
+          setCurrentLayout(serverLayout)
+        }
+      })
+    }
+  }, [authentication?.user?.username])
+
+  // Debounced save: persist layout to server ~1.5s after the last drag/resize,
+  // avoiding excessive API calls during continuous layout changes.
+  useEffect(() => {
+    if (!authentication || !currentLayout) return
+    clearTimeout(layoutSaveTimerRef.current)
+    layoutSaveTimerRef.current = setTimeout(() => {
+      saveServerLayout(server, authentication, currentLayout)
+    }, 1500)
+    return () => clearTimeout(layoutSaveTimerRef.current)
+  }, [currentLayout])
 
   function onReferenceChange(bookId, chapter, verse) {
     setQuote(null)

--- a/src/utils/serverPreferences.js
+++ b/src/utils/serverPreferences.js
@@ -1,0 +1,87 @@
+/**
+ * Server-side user preference storage via DCS Gitea User Settings API.
+ *
+ * Preferences are stored as key-value pairs on the user's Gitea account at:
+ *   GET/PATCH {server}/api/v1/user/settings
+ *
+ * This means preferences persist across browsers, devices, and incognito sessions
+ * (anything that clears localStorage). All functions fail silently so localStorage
+ * remains the authoritative fallback when the server is unavailable.
+ */
+
+const LAYOUT_KEY = 'gateway_edit_resource_layout'
+
+/**
+ * Returns the Authorization header value from an authentication object,
+ * or null if the user is not authenticated.
+ * @param {object} authentication
+ * @return {string|null}
+ */
+function getAuthHeader(authentication) {
+  return authentication?.config?.headers?.Authorization || null
+}
+
+/**
+ * Retrieve the saved resource layout from the user's server account.
+ * Returns null if no layout is stored, if the user is not authenticated,
+ * or if the server request fails.
+ * @param {string} server - base URL, e.g. 'https://git.door43.org'
+ * @param {object} authentication
+ * @return {Promise<object|null>}
+ */
+export async function getServerLayout(server, authentication) {
+  const authHeader = getAuthHeader(authentication)
+  if (!authHeader) return null
+
+  try {
+    const response = await fetch(`${server}/api/v1/user/settings`, {
+      headers: {
+        Authorization: authHeader,
+        'Content-Type': 'application/json',
+      },
+    })
+
+    if (!response.ok) return null
+
+    const settings = await response.json()
+    // Gitea returns an array of {key, value} objects
+    const entry = Array.isArray(settings)
+      ? settings.find(s => s.key === LAYOUT_KEY)
+      : null
+
+    if (!entry?.value) return null
+
+    return JSON.parse(entry.value)
+  } catch (e) {
+    console.warn('getServerLayout() - failed to load layout from server:', e)
+    return null
+  }
+}
+
+/**
+ * Save the current resource layout to the user's server account.
+ * No-ops if the user is not authenticated or if the server request fails.
+ * @param {string} server - base URL, e.g. 'https://git.door43.org'
+ * @param {object} authentication
+ * @param {object} layout - the layout object to persist
+ * @return {Promise<void>}
+ */
+export async function saveServerLayout(server, authentication, layout) {
+  const authHeader = getAuthHeader(authentication)
+  if (!authHeader || !layout) return
+
+  try {
+    await fetch(`${server}/api/v1/user/settings`, {
+      method: 'PATCH',
+      headers: {
+        Authorization: authHeader,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        settings: { [LAYOUT_KEY]: JSON.stringify(layout) },
+      }),
+    })
+  } catch (e) {
+    console.warn('saveServerLayout() - failed to save layout to server:', e)
+  }
+}


### PR DESCRIPTION
Closes #816

  ## Problem

  Layout was stored only in `localStorage` (`{username}_resourceLayout`). Incognito sessions (and any cache clear) wipe it silently, forcing users to
  rearrange cards every time.

  ## Solution

  Use the DCS Gitea User Settings API (`GET`/`PATCH /api/v1/user/settings`) to persist layout server-side so it survives browser restarts, incognito
  windows, and device switches.

  ## Changes

  ### New: `src/utils/serverPreferences.js`
  - `getServerLayout(server, authentication)` — fetches layout from `GET /api/v1/user/settings` key `gateway_edit_resource_layout`.
  - `saveServerLayout(server, authentication, layout)` — `PATCH`es the same key.
  - Both fail silently so localStorage remains the fallback.

  ### Modified: `src/context/StoreContext.jsx`
  - On login: load layout from server (server value wins over stale localStorage).
  - On layout change: debounced (1.5 s) server save to avoid thrashing the API during drag/resize.

  ## Testing
  1. Log in, arrange cards, close incognito window.
  2. Open new incognito window, log back in — layout restored automatically.
  3. Go offline, arrange cards — works normally via localStorage, no errors.
  4. Verify via `GET {server}/api/v1/user/settings` that `gateway_edit_resource_layout` key is present after saving.

  Also includes upstream sync (PRs #805, #806, #811, #812, #815 — escape-key word aligner, login-error fixes, dependency updates).