### PR TITLE
feat: Logos Bible Software sync via logosref: protocol

### DIFF
--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -9,6 +9,7 @@ import ExitToAppIcon from '@material-ui/icons/ExitToApp'
 import SettingsIcon from '@material-ui/icons/Settings'
 import BugReportIcon from '@material-ui/icons/BugReport'
 import DoneAllIcon from '@material-ui/icons/DoneAll';
+import Switch from '@material-ui/core/Switch'
 import IconButton from '@material-ui/core/IconButton'
 import ListItem from '@material-ui/core/ListItem'
 import List from '@material-ui/core/List'
@@ -37,7 +38,8 @@ export default function Drawer({
   showFeedback,
 }) {
   const {
-    state: { mergeStatusForCards, cardsSaving, cardsLoadingMerge },
+    state: { mergeStatusForCards, cardsSaving, cardsLoadingMerge, logosSync },
+    actions: { setLogosSync },
   } = useContext(StoreContext)
 
   const { navigate } = useAppNavigation()
@@ -129,6 +131,28 @@ export default function Drawer({
             <DashboardOutlinedIcon />
           </ListItemIcon>
           <ListItemText primary={'Reset Resource Layout'} />
+        </ListItem>
+        <ListItem
+          button
+          key={'Logos Sync'}
+          onClick={() => setLogosSync(prev => !prev)}
+          title='Sync current verse to Logos Bible Software via logosref: protocol'
+        >
+          <ListItemIcon>
+            <span style={{ fontWeight: 900, fontSize: 14, width: 24, textAlign: 'center', color: 'rgba(0,0,0,0.54)' }}>L</span>
+          </ListItemIcon>
+          <ListItemText
+            primary='Logos Sync'
+            secondary='Follow verse in Logos Bible Software'
+          />
+          <ListItemSecondaryAction>
+            <Switch
+              edge='end'
+              checked={!!logosSync}
+              onChange={e => setLogosSync(e.target.checked)}
+              inputProps={{ 'aria-label': 'Logos Sync' }}
+            />
+          </ListItemSecondaryAction>
         </ListItem>
       </List>
       <Divider />

--- a/src/components/WorkspaceContainer.jsx
+++ b/src/components/WorkspaceContainer.jsx
@@ -48,6 +48,7 @@ import { HTTP_CONFIG } from '@common/constants'
 import NetworkErrorPopup from '@components/NetworkErrorPopUp'
 import WordAlignerDialog from '@components/WordAlignerDialog'
 import useLexicon from '@hooks/useLexicon'
+import useLogosSync from '@hooks/useLogosSync'
 import useWindowDimensions from '@hooks/useWindowDimensions'
 import { translate } from '@utils/lexiconHelpers'
 import { getBuildId } from '@utils/build'
@@ -142,6 +143,7 @@ function WorkspaceContainer() {
       hebrewRepoUrl,
       languageId,
       loggedInUser,
+      logosSync,
       mainScreenRef,
       mergeCheck,
       owner,
@@ -175,6 +177,8 @@ function WorkspaceContainer() {
       updateTaDetails,
     },
   } = useContext(StoreContext)
+
+  useLogosSync({ bookId, chapter, verse, enabled: logosSync })
 
   const [
     {

--- a/src/context/StoreContext.jsx
+++ b/src/context/StoreContext.jsx
@@ -99,6 +99,7 @@ export default function StoreContextProvider(props) {
     chapter: '1',
     verse: '1',
   })
+  const [logosSync, setLogosSync] = useUserLocalStorage('logosSync', false)
 
   const [greekRepoUrl, setGreekRepoUrl] = useLocalStorage('greekRepoUrl', null)
   const [hebrewRepoUrl, setHebrewRepoUrl] = useLocalStorage('hebrewRepoUrl', null)
@@ -183,6 +184,7 @@ export default function StoreContextProvider(props) {
       languageId,
       lastError,
       loggedInUser: username,
+      logosSync,
       mainScreenRef,
       mergeCheck,
       mergeStatusForCards,
@@ -216,6 +218,7 @@ export default function StoreContextProvider(props) {
       setScriptureOwner,
       setLanguageId,
       setLastError,
+      setLogosSync,
       setObsSupport,
       setOwner,
       setQuote,

--- a/src/hooks/useLogosSync.js
+++ b/src/hooks/useLogosSync.js
@@ -1,0 +1,81 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Maps USFM book IDs (used throughout gateway-edit) to Logos Bible Software
+ * abbreviations for use in logosref: URIs.
+ * Format: logosref:Bible.[LogosAbbr][Chapter].[Verse]
+ * e.g.   logosref:Bible.La3.5
+ */
+const LOGOS_BOOK_MAP = {
+  // Old Testament
+  gen: 'Ge',  exo: 'Ex',   lev: 'Le',   num: 'Nu',   deu: 'Dt',
+  jos: 'Jos', jdg: 'Judg', rut: 'Ru',
+  '1sa': '1Sa', '2sa': '2Sa', '1ki': '1Ki', '2ki': '2Ki',
+  '1ch': '1Ch', '2ch': '2Ch',
+  ezr: 'Ezra', neh: 'Ne',  est: 'Es',   job: 'Job',
+  psa: 'Ps',  pro: 'Pr',   ecc: 'Ec',   sng: 'Song',
+  isa: 'Is',  jer: 'Je',   lam: 'La',   ezk: 'Eze',  dan: 'Da',
+  hos: 'Ho',  jol: 'Joe',  amo: 'Am',   oba: 'Ob',   jon: 'Jon',
+  mic: 'Mic', nam: 'Na',   hab: 'Hab',  zep: 'Zep',  hag: 'Hag',
+  zec: 'Zec', mal: 'Mal',
+  // New Testament
+  mat: 'Mt',  mrk: 'Mk',   luk: 'Lk',   jhn: 'Jn',   act: 'Ac',
+  rom: 'Ro',
+  '1co': '1Co', '2co': '2Co',
+  gal: 'Ga',  eph: 'Eph',  php: 'Php',  col: 'Col',
+  '1th': '1Th', '2th': '2Th', '1ti': '1Ti', '2ti': '2Ti',
+  tit: 'Ti',  phm: 'Phm',  heb: 'Heb',  jas: 'Jas',
+  '1pe': '1Pe', '2pe': '2Pe',
+  '1jn': '1Jn', '2jn': '2Jn', '3jn': '3Jn',
+  jud: 'Jude', rev: 'Re',
+}
+
+/**
+ * Build a logosref: URI for the given reference.
+ * @param {string} bookId  USFM book ID (e.g. 'lam')
+ * @param {string|number} chapter
+ * @param {string|number} verse
+ * @returns {string}  e.g. 'logosref:Bible.La3.5'
+ */
+export function buildLogosUri(bookId, chapter, verse) {
+  const abbr = LOGOS_BOOK_MAP[bookId?.toLowerCase()] ?? bookId
+  return `logosref:Bible.${abbr}${chapter}.${verse}`
+}
+
+/**
+ * When `enabled` is true, fires a logosref: URI into a hidden iframe whenever
+ * bookId/chapter/verse changes, causing Logos Bible Software to follow along.
+ *
+ * The iframe approach lets the browser handle the protocol handoff silently
+ * after the user grants the one-time "Allow this site to open Logos?" prompt.
+ * Users without Logos installed are unaffected — the iframe load simply fails.
+ *
+ * @param {object} params
+ * @param {string}  params.bookId   USFM book ID
+ * @param {string}  params.chapter
+ * @param {string}  params.verse
+ * @param {boolean} params.enabled  Controlled by the Logos Sync toggle
+ */
+export default function useLogosSync({ bookId, chapter, verse, enabled }) {
+  const timerRef = useRef(null)
+
+  useEffect(() => {
+    if (!enabled || !bookId) return
+
+    clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => {
+      const uri = buildLogosUri(bookId, chapter, verse)
+      let frame = document.getElementById('logos-sync-frame')
+      if (!frame) {
+        frame = document.createElement('iframe')
+        frame.id = 'logos-sync-frame'
+        frame.style.cssText =
+          'position:fixed;width:1px;height:1px;top:-999px;left:-999px;border:none;'
+        document.body.appendChild(frame)
+      }
+      frame.src = uri
+    }, 300)
+
+    return () => clearTimeout(timerRef.current)
+  }, [bookId, chapter, verse, enabled])
+}


### PR DESCRIPTION
Closes #818

## Summary
- Adds a **Logos Sync** toggle to the drawer menu that follows verse navigation in Logos Bible Software via the `logosref:` URI protocol
- Per-user toggle state persisted in localStorage via `useUserLocalStorage`
- 300 ms debounce prevents flooding Logos during rapid navigation
- Zero impact on users without Logos installed (iframe load silently fails)

## Changes

| File | Change |
|------|--------|
| `src/hooks/useLogosSync.js` | New hook — USFM→Logos book map, debounced iframe fire |
| `src/context/StoreContext.jsx` | Add `logosSync`/`setLogosSync` via `useUserLocalStorage` |
| `src/components/Drawer.jsx` | MUI `Switch` list item for the toggle |
| `src/components/WorkspaceContainer.jsx` | Call `useLogosSync` with current `bookId`/`chapter`/`verse` |

## Test plan
- [ ] Enable toggle in ☰ drawer → navigate verses → Logos jumps to matching verse
- [ ] Disable toggle → navigation no longer affects Logos
- [ ] Toggle state persists across page reload
- [ ] No console errors for users without Logos installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)