### PR TITLE
Fix save failures, phantom logouts, and data loss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ cypress/videos/
 .netlify
 /out/
 /scripts/gatewayedit-desktop/
+
+# Claude Code
+CLAUDE.md

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -10,8 +10,6 @@ export default function ErrorPage({ statusCode }) {
     return <Error statusCode={statusCode} />
   }
 
-  localStorage.clear()
-
   const handleClick = (e) => {
     e.preventDefault()
     router.reload()
@@ -41,7 +39,7 @@ export default function ErrorPage({ statusCode }) {
           <path fill='#D8DCE5' d="M259.17,317.968V216.821c0-3.696,2.69-7.548,7.21-9.96c-2.945-1.518-6.511-2.444-10.271-2.444c-10.494,0-17.544,6.414-17.544,12.404v101.147c0,7.163,7.214,12.166,17.544,12.166c3.934,0,7.449-0.752,10.299-2.069C261.906,325.954,259.17,322.372,259.17,317.968z"/>
         </svg>
         <h2 className='m-0 p-0'>
-          An unexpected error has occurred. The application cache has been cleared.
+          An unexpected error has occurred.
         </h2>
         <button
           onClick={handleClick}

--- a/src/components/NetworkErrorPopUp.jsx
+++ b/src/components/NetworkErrorPopUp.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { NETWORK_ERROR, RETRY } from '@common/constants'
+import { NETWORK_ERROR, RELOAD, RETRY } from '@common/constants'
 import ErrorPopup from '@components/ErrorPopUp'
 import SaveIcon from '@material-ui/icons/Save'
 

--- a/src/components/ResourceCard.jsx
+++ b/src/components/ResourceCard.jsx
@@ -411,7 +411,7 @@ export default function ResourceCard({
 
   async function handleSaveEdit(newContent = '') {
     // Save edit, if successful trigger resource reload and set saved to true.
-    setIsSaving(true) && setCardsSaving(prevCardsSaving => [...prevCardsSaving, cardResourceId])
+    setIsSaving(true); setCardsSaving(prevCardsSaving => [...prevCardsSaving, cardResourceId])
     const saveEdit = async (branch, newContent) => {
       console.log(`handleSaveEdit() saving edit branch`, { sha, resource })
       const success = await onSaveEdit(branch, newContent)
@@ -434,7 +434,7 @@ export default function ResourceCard({
         onResourceError &&
           onResourceError(message, isAccessError, resourceStatus)
       }
-      setIsSaving(false) && setCardsSaving(prevCardsSaving => prevCardsSaving.filter(cardId => cardId !== cardResourceId))
+      setIsSaving(false); setCardsSaving(prevCardsSaving => prevCardsSaving.filter(cardId => cardId !== cardResourceId))
     }
 
     // If not using user branch create it then save the edit.

--- a/src/components/ResourceCard.jsx
+++ b/src/components/ResourceCard.jsx
@@ -240,8 +240,17 @@ export default function ResourceCard({
   } = _useBranchMerger;
 
   useEffect(() => {
-    if (mergeCheck > 0) {
-      checkMergeStatus && checkMergeStatus() // every time mergeCheck changes, check merge status again
+    if (mergeCheck > 0 && checkMergeStatus) {
+      // Wrap in try/catch — dcs-branch-merger can throw on 404/409 from /pulls endpoints
+      // when no PR exists for a resource's user branch. This is normal and should not crash the app.
+      try {
+        const result = checkMergeStatus()
+        if (result && typeof result.catch === 'function') {
+          result.catch(err => console.warn(`ResourceCard(${cardResourceId}) merge check failed:`, err?.message || err))
+        }
+      } catch (err) {
+        console.warn(`ResourceCard(${cardResourceId}) merge check threw:`, err?.message || err)
+      }
     }
   }, [mergeCheck])
 

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -55,8 +55,13 @@ export default function AuthContextProvider(props) {
       try {
         const response = await doFetch(`${server}/api/v1/user`, auth, HTTP_GET_MAX_WAIT_TIME);
         const httpCode = response?.status || 0;
-        auth = (httpCode === 200)
-        results.authenticated = auth
+        if (httpCode === 200) {
+          results.authenticated = true
+        } else if (unAuthenticated(httpCode)) {
+          results.authenticationError = `Server returned ${httpCode}`
+        } else {
+          results.otherError = `Server returned ${httpCode}`
+        }
       } catch (e) {
         if (e.toString().includes('401')) { // check if 401 code in exception
           results.authenticationError = e.toString();

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -31,7 +31,7 @@ export default function AuthContextProvider(props) {
    * @param {number} httpCode - http code returned
    */
   function processError(error, httpCode=0) {
-    processNetworkError(error, httpCode, null, null, setNetworkError, null, null )
+    processNetworkError(error, httpCode, logout, null, setNetworkError, null, null )
   }
 
   const myAuthStore = localforage.createInstance({
@@ -59,11 +59,9 @@ export default function AuthContextProvider(props) {
         results.authenticated = auth
       } catch (e) {
         if (e.toString().includes('401')) { // check if 401 code in exception
-          // console.error(`getAuth() - user token expired`)
           results.authenticationError = e.toString();
         } else {
-          // console.warn(`getAuth() - hard error fetching user info, error=`, e)
-          results.authenticationError = e.toString();
+          results.otherError = e.toString();
         }
       }
     }
@@ -93,29 +91,31 @@ export default function AuthContextProvider(props) {
     const auth = await myAuthStore.getItem('authentication')
 
     if (auth) { // verify that auth is still valid
-      doFetch(`${server}/api/v1/user`, auth, HTTP_GET_MAX_WAIT_TIME)
-        .then(response => {
-          const httpCode = response?.status || 0
+      try {
+        const response = await doFetch(`${server}/api/v1/user`, auth, HTTP_GET_MAX_WAIT_TIME)
+        const httpCode = response?.status || 0
 
-          if (httpCode !== 200) {
-            console.log(`getAuth() - error fetching user info, status code ${httpCode}`)
+        if (httpCode !== 200) {
+          console.log(`getAuth() - error fetching user info, status code ${httpCode}`)
 
-            if (unAuthenticated(httpCode)) {
-              console.error(`getAuth() - user not authenticated, going to login`)
-              logout()
-            } else {
-              processError(null, httpCode)
-            }
-          }
-        }).catch(e => {
-          if (e.toString().includes('401')) { // check if 401 code in exception
-            console.error(`getAuth() - user token expired`)
-            logout()
+          if (unAuthenticated(httpCode)) {
+            console.error(`getAuth() - user not authenticated, going to login`)
+            await logout()
+            return null
           } else {
-            console.warn(`getAuth() - hard error fetching user info, error=`, e)
-            processError(e)
+            processError(null, httpCode)
           }
-        })
+        }
+      } catch (e) {
+        if (e.toString().includes('401')) { // check if 401 code in exception
+          console.error(`getAuth() - user token expired`)
+          await logout()
+          return null
+        } else {
+          // Network error — don't logout, just warn. Token may still be valid.
+          console.warn(`getAuth() - hard error fetching user info, error=`, e)
+        }
+      }
     }
     return auth
   }

--- a/src/hooks/useSaveChangesPrompt.jsx
+++ b/src/hooks/useSaveChangesPrompt.jsx
@@ -75,16 +75,8 @@ export default function useSaveChangesPrompt() {
   useEffect(() => {
     const handleBeforeunload = (event) => {
       event.preventDefault()
-
-      // Chrome requires `returnValue` to be set.
-      if (event.defaultPrevented) {
-        event.returnValue = ''
-      }
-
-      if (typeof returnValue === 'string') {
-        event.returnValue = promptText
-        return promptText
-      }
+      event.returnValue = promptText
+      return promptText
     }
 
     if (!savedChanges) {

--- a/src/utils/network.js
+++ b/src/utils/network.js
@@ -272,9 +272,9 @@ export function doFetch(url, authentication={}, timeout=HTTP_GET_MAX_WAIT_TIME, 
   return get({
     url: url,
     config: {
+      server: BASE_URL,
       ...authConfig,
       timeout: timeout,
-      server: BASE_URL,
     },
     noCache: noCache,
     fullResponse: true,


### PR DESCRIPTION
## Summary

Fixes 6 bugs causing save failures, phantom logouts, and silent data loss:

- **`setCardsSaving()` never executes** — `ResourceCard.jsx:414,437` used `&&` to chain `setState` calls, but `setState` returns `undefined`, so the second call was short-circuited. Changed to `;` so both execute.
- **Broken `beforeunload` handler** — `useSaveChangesPrompt.jsx:84` checked `typeof returnValue` (undeclared variable) instead of `typeof event.returnValue`. Browser "leave page?" dialog never appeared. Simplified to standard cross-browser pattern.
- **`getAuth()` fire-and-forget verification** — `AuthContext.jsx:92-121` returned cached auth immediately while asynchronously verifying it. Any transient network error called `logout()` in the background, wiping auth for ALL open tabs. Now awaits verification; only logs out on confirmed 401/403, not network errors.
- **`checkUserAuthentication()` misclassifies all errors as auth failures** — Both branches of the catch block set `authenticationError`. Non-401 errors now correctly set `otherError`.
- **`processError()` error popup buttons non-functional** — Passed `null` for `logout`, making the Login button a no-op. Now passes `logout` callback.
- **`localStorage.clear()` in error page** — `_error.js` wiped ALL localStorage for the origin on any unhandled client-side error, affecting all tabs. Removed.

## Multi-tab impact

The `getAuth()` fix is the most impactful for multi-tab users. Previously, one background tab experiencing a network timeout would call `logout()`, clearing the shared `my-auth-store` IndexedDB and silently logging out all other tabs. Combined with the broken `beforeunload`, users would close tabs and lose work without warning.

Closes #822
Closes #823

## Test plan

- [ ] Edit content → close tab → browser shows "leave page?" dialog
- [ ] Save a card → UI shows spinner on the saving card
- [ ] Temporarily disconnect network → reconnect → user is NOT logged out
- [ ] Trigger network error → error popup Login button works
- [ ] Open 2 tabs → trigger network error in tab 1 → tab 2 retains auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)